### PR TITLE
Add script to compute non-prompt fraction with data-driven approach

### DIFF
--- a/CombineAccTimesEff.py
+++ b/CombineAccTimesEff.py
@@ -5,18 +5,15 @@ run: python CombineAccTimesEff.py effFileName.root accFileName.root outFileName.
 
 import math
 import argparse
-import string
-import six
 from ROOT import gROOT, TFile, TCanvas, TH1F, TLegend  # pylint: disable=import-error,no-name-in-module
-from ROOT import kBlack, kFullDiamond  # pylint: disable=import-error,no-name-in-module
-from utils.StyleFormatter import SetGlobalStyle
+from ROOT import kBlack, kFullDiamond, kRed, kAzure, kFullCircle, kOpenSquare  # pylint: disable=import-error,no-name-in-module
+from utils.StyleFormatter import SetGlobalStyle, SetObjectStyle
 
 parser = argparse.ArgumentParser(description='Arguments')
 parser.add_argument('effFileName', metavar='text', default='')
 parser.add_argument('accFileName', metavar='text', default='')
 parser.add_argument('outFileName', metavar='text', default='')
-parser.add_argument("--batch", help="suppress video output",
-                    action="store_true")
+parser.add_argument("--batch", help="suppress video output", action="store_true")
 args = parser.parse_args()
 
 gROOT.SetBatch(args.batch)
@@ -25,6 +22,8 @@ SetGlobalStyle()
 effFile = TFile.Open(args.effFileName)
 hEffPrompt = effFile.Get('hEffPrompt')
 hEffFD = effFile.Get('hEffFD')
+SetObjectStyle(hEffPrompt, color=kRed+1, markerstyle=kFullCircle)
+SetObjectStyle(hEffFD, color=kAzure+4, markerstyle=kOpenSquare, markersize=1.5, linewidh=2, linestyle=7)
 
 accFile = TFile.Open(args.accFileName)
 hAccNum = accFile.Get('hPtGenAcc')
@@ -83,11 +82,6 @@ hAccEffFD.Write()
 outFile.Close()
 
 if not args.batch:
-    if six.PY2:
-        outFileNamePDF = string.replace(args.outFileName, '.root', '.pdf')
-        cAccEff.SaveAs(outFileNamePDF)
-        raw_input('Press enter to exit')
-    elif six.PY3:
-        outFileNamePDF = args.outFileName.replace('.root', '.pdf')
-        cAccEff.SaveAs(outFileNamePDF)
-        input('Press enter to exit')
+    outFileNamePDF = args.outFileName.replace('.root', '.pdf')
+    cAccEff.SaveAs(outFileNamePDF)
+    input('Press enter to exit')

--- a/ComputeCutVarPromptFrac.py
+++ b/ComputeCutVarPromptFrac.py
@@ -20,6 +20,7 @@ args = parser.parse_args()
 
 outFileNameEffPDF = args.outFileName.replace('.root', '_Eff.pdf')
 outFileNameDistrPDF = args.outFileName.replace('.root', '_Distr.pdf')
+outFileNameFracPDF = args.outFileName.replace('.root', '_Frac.pdf')
 
 with open(args.cfgFileName, 'r') as ymlCutSetFile:
     cutSetCfg = yaml.load(ymlCutSetFile, yaml.FullLoader)
@@ -206,22 +207,28 @@ hCorrYieldFD.Write()
 for iPt in range(hRawYields[0].GetNbinsX()):
     cDistr[iPt].Write()
     cEff[iPt].Write()
+    cFrac[iPt].Write()
     hRawYieldsVsCut[iPt].Write()
     hRawYieldPromptVsCut[iPt].Write()
     hRawYieldFDVsCut[iPt].Write()
     hRawYieldsVsCutReSum[iPt].Write()
     hEffPromptVsCut[iPt].Write()
     hEffFDVsCut[iPt].Write()
+    hPromptFracVsCut[iPt].Write()
+    hFDFracVsCut[iPt].Write()
 outFile.Close()
 
 for iPt in range(hRawYields[0].GetNbinsX()):
     if iPt == 0:
         cEff[iPt].SaveAs('{}['.format(outFileNameEffPDF))
         cDistr[iPt].SaveAs('{}['.format(outFileNameDistrPDF))
+        cFrac[iPt].SaveAs('{}['.format(outFileNameFracPDF))
     cEff[iPt].SaveAs(outFileNameEffPDF)
     cDistr[iPt].SaveAs(outFileNameDistrPDF)
+    cFrac[iPt].SaveAs(outFileNameFracPDF)
     if iPt == hRawYields[0].GetNbinsX()-1:
         cEff[iPt].SaveAs('{}]'.format(outFileNameEffPDF))
         cDistr[iPt].SaveAs('{}]'.format(outFileNameDistrPDF))
+        cFrac[iPt].SaveAs('{}]'.format(outFileNameFracPDF))
 
 input('Press enter to exit')

--- a/ComputeCutVarPromptFrac.py
+++ b/ComputeCutVarPromptFrac.py
@@ -1,0 +1,227 @@
+'''
+python script for the computation of the prompt / non-prompt fraction with the cut-variation method
+run: python ComputeCutVarPromptFrac.py cfgFileName.yml outFileName.root
+'''
+
+import argparse
+import numpy as np
+import yaml
+from ROOT import TFile, TH1F, TCanvas, TLegend  # pylint: disable=import-error,no-name-in-module
+from ROOT import kBlack, kRed, kAzure, kGreen, kFullCircle, kFullSquare, kOpenSquare  # pylint: disable=import-error,no-name-in-module
+from utils.AnalysisUtils import GetPromptFDYieldsAnalyticMinimisation
+from utils.StyleFormatter import SetGlobalStyle, SetObjectStyle
+
+parser = argparse.ArgumentParser(description='Arguments to pass')
+parser.add_argument('cfgFileName', metavar='text', default='cfgFileName.yml',
+                    help='config file name with root input files')
+parser.add_argument('outFileName', metavar='text', default='outFile.root',
+                    help='output root file name')
+args = parser.parse_args()
+
+outFileNameEffPDF = args.outFileName.replace('.root', '_Eff.pdf')
+outFileNameDistrPDF = args.outFileName.replace('.root', '_Distr.pdf')
+
+with open(args.cfgFileName, 'r') as ymlCutSetFile:
+    cutSetCfg = yaml.load(ymlCutSetFile, yaml.FullLoader)
+
+if len(cutSetCfg['rawyields']['inputfiles']) != len(cutSetCfg['efficiencies']['inputfiles']):
+    print('ERROR: number or raw yield files and efficiency files not consistent! Please check your config file. Exit')
+    exit()
+
+SetGlobalStyle(padleftmargin=0.15, titleoffsetx=1., titleoffsety=1.4)
+
+nSets = len(cutSetCfg['rawyields']['inputfiles'])
+
+hRawYields, hEffPrompt, hEffFD = [], [], []
+for iCutSet, (inFileNameRawYield, inFileNameEff) in enumerate(
+        zip(cutSetCfg['rawyields']['inputfiles'], cutSetCfg['efficiencies']['inputfiles'])):
+
+    inFileRawYield = TFile.Open(inFileNameRawYield)
+    hRawYields.append(inFileRawYield.Get(cutSetCfg['rawyields']['histoname']))
+    hRawYields[-1].SetDirectory(0)
+
+    inFileEff = TFile.Open(inFileNameEff)
+    hEffPrompt.append(inFileEff.Get(cutSetCfg['efficiencies']['histonames']['prompt']))
+    hEffFD.append(inFileEff.Get(cutSetCfg['efficiencies']['histonames']['feeddown']))
+    hEffPrompt[-1].SetDirectory(0)
+    hEffFD[-1].SetDirectory(0)
+
+legDistr = TLegend(0.4, 0.7, 0.7, 0.9)
+legDistr.SetFillStyle(0)
+legDistr.SetBorderSize(0)
+legDistr.SetTextSize(0.05)
+
+legEff = TLegend(0.2, 0.2, 0.4, 0.4)
+legEff.SetFillStyle(0)
+legEff.SetBorderSize(0)
+legEff.SetTextSize(0.05)
+
+hCorrYieldPrompt = hRawYields[0].Clone('hCorrYieldPrompt')
+hCorrYieldPrompt.SetTitle(';#it{p}_{T} (GeV/#it{c}); #it{N}_{prompt}')
+SetObjectStyle(hCorrYieldPrompt, color=kRed+1, fillcolor=kRed + 1, markerstyle=kFullCircle, fillalpha=0.3)
+
+hCorrYieldFD = hRawYields[0].Clone('hCorrYieldFD')
+hCorrYieldFD.SetTitle(';#it{p}_{T} (GeV/#it{c}); #it{N}_{non-prompt}')
+SetObjectStyle(hCorrYieldFD, color=kAzure+4, fillcolor=kAzure + 4, markerstyle=kOpenSquare, fillalpha=0.3)
+
+hRawYieldsVsCut, hRawYieldsVsCutReSum, hRawYieldPromptVsCut, hRawYieldFDVsCut, cDistr = ([] for _ in range(5))
+hEffPromptVsCut, hEffFDVsCut, cEff = ([] for _ in range(3))
+hPromptFracVsCut, hFDFracVsCut, cFrac = ([] for _ in range(3))
+for iPt in range(hRawYields[0].GetNbinsX()):
+    ptMin = hRawYields[0].GetBinLowEdge(iPt+1)
+    ptMax = ptMin + hRawYields[0].GetBinWidth(iPt+1)
+
+    listRawYield = [hRaw.GetBinContent(iPt+1) for hRaw in hRawYields]
+    listRawYieldUnc = [hRaw.GetBinError(iPt+1) for hRaw in hRawYields]
+
+    listEffPrompt = [hEffP.GetBinContent(iPt+1) for hEffP in hEffPrompt]
+    listEffPromptUnc = [hEffP.GetBinError(iPt+1) for hEffP in hEffPrompt]
+
+    listEffFD = [hEffF.GetBinContent(iPt+1) for hEffF in hEffFD]
+    listEffFDUnc = [hEffF.GetBinError(iPt+1) for hEffF in hEffFD]
+
+    corrYields, covMatrixCorrYields = GetPromptFDYieldsAnalyticMinimisation(\
+        listEffPrompt, listEffFD, listRawYield, listEffPromptUnc, listEffFDUnc, listRawYieldUnc)
+
+    hCorrYieldPrompt.SetBinContent(iPt+1, corrYields.item(0))
+    hCorrYieldPrompt.SetBinError(iPt+1, np.sqrt(covMatrixCorrYields.item(0, 0)))
+    hCorrYieldFD.SetBinContent(iPt+1, corrYields.item(1))
+    hCorrYieldFD.SetBinError(iPt+1, np.sqrt(covMatrixCorrYields.item(1, 1)))
+
+    hRawYieldsVsCut.append(TH1F('hRawYieldsVsCutPt_pT{0:.0f}_{1:.0f}'.format(ptMin, ptMax), ';cut set;raw yield',
+                                nSets, 0.5, nSets+0.5))
+    hRawYieldsVsCutReSum.append(TH1F('hRawYieldsVsCutReSum_pT{0:.0f}_{1:.0f}'.format(ptMin, ptMax),
+                                     ';cut set;raw yield', nSets, 0.5, nSets+0.5))
+    hRawYieldPromptVsCut.append(TH1F('hRawYieldPromptVsCut_pT{0:.0f}_{1:.0f}'.format(ptMin, ptMax),
+                                     ';cut set;raw yield', nSets, 0.5, nSets+0.5))
+    hRawYieldFDVsCut.append(TH1F('hRawYieldFDVsCut_pT{0:.0f}_{1:.0f}'.format(ptMin, ptMax), ';cut set;raw yield',
+                                 nSets, 0.5, nSets+0.5))
+    hEffPromptVsCut.append(TH1F('hEffPromptVsCut_pT{0:.0f}_{1:.0f}'.format(ptMin, ptMax), ';cut set;efficiency',
+                                nSets, 0.5, nSets+0.5))
+    hEffFDVsCut.append(TH1F('hEffFDVsCut_pT{0:.0f}_{1:.0f}'.format(ptMin, ptMax), ';cut set;efficiency',
+                            nSets, 0.5, nSets+0.5))
+    hPromptFracVsCut.append(TH1F('hPromptFracVsCut_pT{0:.0f}_{1:.0f}'.format(ptMin, ptMax), ';cut set;#it{f}_{prompt}',
+                            nSets, 0.5, nSets+0.5))
+    hFDFracVsCut.append(TH1F('hFDFracVsCut_pT{0:.0f}_{1:.0f}'.format(ptMin, ptMax), ';cut set;#it{f}_{FD}',
+                        nSets, 0.5, nSets+0.5))
+
+    SetObjectStyle(hRawYieldsVsCut[iPt], linecolor=kBlack, markercolor=kBlack, markerstyle=kFullSquare)
+    SetObjectStyle(hRawYieldPromptVsCut[iPt], color=kRed+1, fillcolor=kRed+1, markerstyle=kFullCircle, fillalpha=0.3)
+    SetObjectStyle(hRawYieldFDVsCut[iPt], color=kAzure+4, fillcolor=kAzure+4, markerstyle=kOpenSquare, fillalpha=0.3)
+    SetObjectStyle(hRawYieldsVsCutReSum[iPt], linecolor=kGreen+2)
+    SetObjectStyle(hEffPromptVsCut[iPt], color=kRed+1, markerstyle=kFullCircle, fillalpha=0.3)
+    SetObjectStyle(hEffFDVsCut[iPt], color=kAzure+4, markerstyle=kOpenSquare, fillalpha=0.3)
+    SetObjectStyle(hPromptFracVsCut[iPt], color=kRed+1, markerstyle=kFullCircle, fillalpha=0.3)
+    SetObjectStyle(hFDFracVsCut[iPt], color=kAzure+4, markerstyle=kOpenSquare, fillalpha=0.3)
+
+    for iCutSet, (rawY, effP, effF, rawYunc, effPunc, effFunc) in enumerate(zip(
+            listRawYield, listEffPrompt, listEffFD, listRawYieldUnc, listEffPromptUnc, listEffFDUnc)):
+
+        #efficiency
+        hEffPromptVsCut[iPt].SetBinContent(iCutSet+1, effP)
+        hEffPromptVsCut[iPt].SetBinError(iCutSet+1, effPunc)
+
+        hEffFDVsCut[iPt].SetBinContent(iCutSet+1, effF)
+        hEffFDVsCut[iPt].SetBinError(iCutSet+1, effFunc)
+
+        #raw yields (including prompt and non-prompt raw yields)
+        hRawYieldsVsCut[iPt].SetBinContent(iCutSet+1, rawY)
+        hRawYieldsVsCut[iPt].SetBinError(iCutSet+1, rawYunc)
+
+        hRawYieldPromptVsCut[iPt].SetBinContent(iCutSet+1, corrYields.item(0)*effP)
+        hRawYieldPromptVsCut[iPt].SetBinError(iCutSet+1, np.sqrt(covMatrixCorrYields.item(0, 0))*effP)
+
+        hRawYieldFDVsCut[iPt].SetBinContent(iCutSet+1, corrYields.item(1)*effF)
+        hRawYieldFDVsCut[iPt].SetBinError(iCutSet+1, np.sqrt(covMatrixCorrYields.item(1, 1))*effF)
+
+        hRawYieldsVsCutReSum[iPt].SetBinContent(iCutSet+1, \
+            hRawYieldPromptVsCut[iPt].GetBinContent(iCutSet+1)+hRawYieldFDVsCut[iPt].GetBinContent(iCutSet+1))
+
+        #prompt fraction
+        fPrompt = effP * corrYields.item(0) / (effP * corrYields.item(0) + effF * corrYields.item(1))
+        defPdeNP = (effP * (effP * corrYields.item(0) + effF * corrYields.item(1)) - effP**2
+                    * corrYields.item(0)) / (effP * corrYields.item(0) + effF * corrYields.item(1))**2
+        defPdeNF = - effF * effP * corrYields.item(0) / (effP * corrYields.item(0) + effF * corrYields.item(1))**2
+        fPromptUnc = np.sqrt(defPdeNP**2 * covMatrixCorrYields.item(0, 0) + \
+            defPdeNF**2 * covMatrixCorrYields.item(1, 1) + \
+            2 * defPdeNP * defPdeNF * covMatrixCorrYields.item(1, 0))
+
+
+        fFD = effF * corrYields.item(1) / (effP * corrYields.item(0) + effF * corrYields.item(1))
+        defFdeNF = (effF * (effF * corrYields.item(1) + effP * corrYields.item(0)) - effF**2
+                    * corrYields.item(1)) / (effP * corrYields.item(0) + effF * corrYields.item(1))**2
+        defFdeNP = - effF * effP * corrYields.item(1) / (effP * corrYields.item(0) + effF * corrYields.item(1))**2
+        fFDUnc = np.sqrt(defFdeNF**2 * covMatrixCorrYields.item(1, 1) + \
+            defFdeNP**2 * covMatrixCorrYields.item(0, 0) + \
+            2 * defFdeNF * defFdeNP * covMatrixCorrYields.item(1, 0))
+
+        hPromptFracVsCut[iPt].SetBinContent(iCutSet+1, fPrompt)
+        hPromptFracVsCut[iPt].SetBinError(iCutSet+1, fPromptUnc)
+        hFDFracVsCut[iPt].SetBinContent(iCutSet+1, fFD)
+        hFDFracVsCut[iPt].SetBinError(iCutSet+1, fFDUnc)
+
+    if iPt == 0:
+        legDistr.AddEntry(hRawYieldsVsCut[iPt], 'Measured raw yield', 'lpe')
+        legDistr.AddEntry(hRawYieldPromptVsCut[iPt], 'Prompt', 'f')
+        legDistr.AddEntry(hRawYieldFDVsCut[iPt], 'Non-prompt', 'f')
+        legDistr.AddEntry(hRawYieldsVsCutReSum[iPt], 'Prompt + non-prompt', 'l')
+
+        legEff.AddEntry(hEffPromptVsCut[iPt], 'Prompt', 'lpe')
+        legEff.AddEntry(hEffFDVsCut[iPt], 'Non-prompt', 'lpe')
+
+    cEff.append(TCanvas('cEff_pT{0:.0f}_{1:.0f}'.format(ptMin, ptMax), '', 800, 800))
+    cEff[iPt].DrawFrame(0.5, 1.e-5, nSets+0.5, 1., ';cut set;efficiency')
+    cEff[iPt].SetLogy()
+    hEffPromptVsCut[iPt].DrawCopy('same')
+    hEffFDVsCut[iPt].DrawCopy('same')
+    legEff.Draw()
+
+    cDistr.append(TCanvas('cDistr_pT{0:.0f}_{1:.0f}'.format(ptMin, ptMax), '', 800, 800))
+    cDistr[iPt].DrawFrame(0.5, 0., nSets+0.5, hRawYieldsVsCut[iPt].GetMaximum()*1.2, ';cut set;raw yield')
+    hRawYieldsVsCut[iPt].Draw('same')
+    hRawYieldPromptVsCut[iPt].DrawCopy('histsame')
+    hRawYieldFDVsCut[iPt].DrawCopy('histsame')
+    hRawYieldsVsCutReSum[iPt].Draw('same')
+    legDistr.Draw()
+
+    cFrac.append(TCanvas('cFrac_pT{0:.0f}_{1:.0f}'.format(ptMin, ptMax), '', 800, 800))
+    cFrac[iPt].DrawFrame(0.5, 0., nSets+0.5, 1., ';cut set;fraction')
+    hPromptFracVsCut[iPt].DrawCopy('Esame')
+    hFDFracVsCut[iPt].DrawCopy('Esame')
+    legEff.Draw()
+
+nPtBins = hCorrYieldPrompt.GetNbinsX()
+cCorrYield = TCanvas('cCorrYield', '', 800, 800)
+cCorrYield.DrawFrame(hCorrYieldPrompt.GetBinLowEdge(1), 1.,
+                     hCorrYieldPrompt.GetBinLowEdge(nPtBins)+hCorrYieldPrompt.GetBinWidth(nPtBins),
+                     hCorrYieldPrompt.GetMaximum()*1.2, ';#it{p}_{T} (GeV/#it{c});corrected yield')
+cCorrYield.SetLogy()
+hCorrYieldPrompt.Draw('same')
+hCorrYieldFD.Draw('same')
+
+outFile = TFile(args.outFileName, 'recreate')
+cCorrYield.Write()
+hCorrYieldPrompt.Write()
+hCorrYieldFD.Write()
+for iPt in range(hRawYields[0].GetNbinsX()):
+    cDistr[iPt].Write()
+    cEff[iPt].Write()
+    hRawYieldsVsCut[iPt].Write()
+    hRawYieldPromptVsCut[iPt].Write()
+    hRawYieldFDVsCut[iPt].Write()
+    hRawYieldsVsCutReSum[iPt].Write()
+    hEffPromptVsCut[iPt].Write()
+    hEffFDVsCut[iPt].Write()
+outFile.Close()
+
+for iPt in range(hRawYields[0].GetNbinsX()):
+    if iPt == 0:
+        cEff[iPt].SaveAs('{}['.format(outFileNameEffPDF))
+        cDistr[iPt].SaveAs('{}['.format(outFileNameDistrPDF))
+    cEff[iPt].SaveAs(outFileNameEffPDF)
+    cDistr[iPt].SaveAs(outFileNameDistrPDF)
+    if iPt == hRawYields[0].GetNbinsX()-1:
+        cEff[iPt].SaveAs('{}]'.format(outFileNameEffPDF))
+        cDistr[iPt].SaveAs('{}]'.format(outFileNameDistrPDF))
+
+input('Press enter to exit')

--- a/ComputeEfficiencyDplusDs.py
+++ b/ComputeEfficiencyDplusDs.py
@@ -5,26 +5,12 @@ run: python ComputeEfficiencyDplusDs.py fitConfigFileName.yml centClass inputFil
 
 import array
 import math
-import string
 import argparse
-import six
 import yaml
 from ROOT import TFile, TCanvas, TH1F, TLegend  # pylint: disable=import-error,no-name-in-module
-from ROOT import gROOT, kRed, kBlue, kFullCircle, kOpenSquare  # pylint: disable=import-error,no-name-in-module
+from ROOT import gROOT, kRed, kAzure, kFullCircle, kOpenSquare  # pylint: disable=import-error,no-name-in-module
+from utils.AnalysisUtils import ComputeEfficiency
 from utils.StyleFormatter import SetGlobalStyle, SetObjectStyle
-
-def ComputeEfficiency(recoCounts, genCounts, recoCountsError, genCountsError):
-    '''
-    method to compute efficiency
-    '''
-    hTmpNum = TH1F('hTmpNum', '', 1, 0, 1)
-    hTmpDen = TH1F('hTmpDen', '', 1, 0, 1)
-    hTmpNum.SetBinContent(1, recoCounts)
-    hTmpDen.SetBinContent(1, genCounts)
-    hTmpNum.SetBinError(1, recoCountsError)
-    hTmpDen.SetBinError(1, genCountsError)
-    hTmpNum.Divide(hTmpNum, hTmpDen, 1., 1, 'B')
-    return hTmpNum.GetBinContent(1), hTmpNum.GetBinError(1)
 
 
 parser = argparse.ArgumentParser(description='Arguments')
@@ -67,12 +53,12 @@ hYieldPromptGen = TH1F('hYieldPromptGen', ';#it{p}_{T} (GeV/#it{c}); # Generated
 hYieldFDGen = TH1F('hYieldFDGen', ';#it{p}_{T} (GeV/#it{c}); # Generated MC', nPtBins, array.array('f', PtLims))
 hYieldPromptReco = TH1F('hYieldPromptReco', ';#it{p}_{T} (GeV/#it{c}); # Reco MC', nPtBins, array.array('f', PtLims))
 hYieldFDReco = TH1F('hYieldFDReco', ';#it{p}_{T} (GeV/#it{c}); # Reco MC', nPtBins, array.array('f', PtLims))
-SetObjectStyle(hEffPrompt, color=kRed, markerstyle=kFullCircle)
-SetObjectStyle(hEffFD, color=kBlue, markerstyle=kOpenSquare, markersize=1.5, linewidh=2, linestyle=7)
-SetObjectStyle(hYieldPromptGen, color=kRed, markerstyle=kFullCircle)
-SetObjectStyle(hYieldFDGen, color=kBlue, markerstyle=kOpenSquare, markersize=1.5, linewidh=2, linestyle=7)
-SetObjectStyle(hYieldPromptReco, color=kRed, markerstyle=kFullCircle)
-SetObjectStyle(hYieldFDReco, color=kBlue, markerstyle=kOpenSquare, markersize=1.5, linewidh=2, linestyle=7)
+SetObjectStyle(hEffPrompt, color=kRed+1, markerstyle=kFullCircle)
+SetObjectStyle(hEffFD, color=kAzure+4, markerstyle=kOpenSquare, markersize=1.5, linewidh=2, linestyle=7)
+SetObjectStyle(hYieldPromptGen, color=kRed+1, markerstyle=kFullCircle)
+SetObjectStyle(hYieldFDGen, color=kAzure+4, markerstyle=kOpenSquare, markersize=1.5, linewidh=2, linestyle=7)
+SetObjectStyle(hYieldPromptReco, color=kRed+1, markerstyle=kFullCircle)
+SetObjectStyle(hYieldFDReco, color=kAzure+4, markerstyle=kOpenSquare, markersize=1.5, linewidh=2, linestyle=7)
 
 if args.ptweights:
     infileWeigts = TFile.Open(args.ptweights[0])
@@ -130,8 +116,6 @@ leg.SetFillStyle(0)
 leg.AddEntry(hEffPrompt, "Prompt", "p")
 leg.AddEntry(hEffFD, "Feed-down", "p")
 
-hEffPrompt.SetDirectory(0)
-hEffFD.SetDirectory(0)
 cEff = TCanvas('cEff', '', 800, 800)
 cEff.DrawFrame(PtMin[0], 1.e-5, PtMax[nPtBins-1], 1.,
                ';#it{p}_{T} (GeV/#it{c});Efficiency;')
@@ -150,11 +134,6 @@ hYieldFDReco.Write()
 outFile.Close()
 
 if not args.batch:
-    if six.PY2:
-        outFileNamePDF = string.replace(args.outFileName, '.root', '.pdf')
-        cEff.SaveAs(outFileNamePDF)
-        raw_input('Press enter to exit')
-    elif six.PY3:
-        outFileNamePDF = args.outFileName.replace('.root', '.pdf')
-        cEff.SaveAs(outFileNamePDF)
-        input('Press enter to exit')
+    outFileNamePDF = args.outFileName.replace('.root', '.pdf')
+    cEff.SaveAs(outFileNamePDF)
+    input('Press enter to exit')

--- a/configfiles/datadrivenfprompt/config_Dplus_PromptFrac_pp5TeV.yml
+++ b/configfiles/datadrivenfprompt/config_Dplus_PromptFrac_pp5TeV.yml
@@ -1,0 +1,8 @@
+rawyields:
+    inputfiles: [../AnalysisNonPromptDpp2017/Dplus/outputs/rawyields/RawYieldsDplus_FD0dot1.root, ../AnalysisNonPromptDpp2017/Dplus/outputs/rawyields/RawYieldsDplus_FD0dot3.root, ../AnalysisNonPromptDpp2017/Dplus/outputs/rawyields/RawYieldsDplus_FD0dot5.root, ../AnalysisNonPromptDpp2017/Dplus/outputs/rawyields/RawYieldsDplus_FD0dot7.root, ../AnalysisNonPromptDpp2017/Dplus/outputs/rawyields/RawYieldsDplus_FD0dot9.root, ../AnalysisNonPromptDpp2017/Dplus/outputs/rawyields/RawYieldsDplus_FD1dot1.root, ../AnalysisNonPromptDpp2017/Dplus/outputs/rawyields/RawYieldsDplus_FD1dot3.root, ../AnalysisNonPromptDpp2017/Dplus/outputs/rawyields/RawYieldsDplus_FD1dot5.root, ../AnalysisNonPromptDpp2017/Dplus/outputs/rawyields/RawYieldsDplus_FD1dot7.root]
+    histoname: hRawYields
+efficiencies:
+    inputfiles: [../AnalysisNonPromptDpp2017/Dplus/outputs/efficiency/EffAccDplus_FD0dot1.root, ../AnalysisNonPromptDpp2017/Dplus/outputs/efficiency/EffAccDplus_FD0dot3.root, ../AnalysisNonPromptDpp2017/Dplus/outputs/efficiency/EffAccDplus_FD0dot5.root, ../AnalysisNonPromptDpp2017/Dplus/outputs/efficiency/EffAccDplus_FD0dot7.root, ../AnalysisNonPromptDpp2017/Dplus/outputs/efficiency/EffAccDplus_FD0dot9.root, ../AnalysisNonPromptDpp2017/Dplus/outputs/efficiency/EffAccDplus_FD1dot1.root, ../AnalysisNonPromptDpp2017/Dplus/outputs/efficiency/EffAccDplus_FD1dot3.root, ../AnalysisNonPromptDpp2017/Dplus/outputs/efficiency/EffAccDplus_FD1dot5.root, ../AnalysisNonPromptDpp2017/Dplus/outputs/efficiency/EffAccDplus_FD1dot7.root]
+    histonames:
+        prompt: hAccEffPrompt
+        feeddown: hAccEffFD

--- a/configfiles/fit/config_Dplus_Fit_pp5TeV.yml
+++ b/configfiles/fit/config_Dplus_Fit_pp5TeV.yml
@@ -1,0 +1,34 @@
+pp5TeVPrompt:
+    Meson: 'Dplus'
+    FixSigma: 0
+    SigmaFile: ''
+    SigmaMultFactor: 1.
+    FixMean: 0
+    MeanFile: ''
+    PtMin: [ 1, 2, 3, 4, 5, 6, 7, 8, 10, 12, 16, 24]   
+    PtMax: [ 2, 3, 4, 5, 6, 7, 8, 10, 12, 16, 24, 36]
+    MassMin: [ 1.74, 1.74, 1.74, 1.74, 1.74, 1.74, 1.74, 1.74, 1.74, 1.74, 1.74, 1.74]    
+    MassMax: [ 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00]
+    Rebin: [ 5, 5, 5, 5, 6, 6, 6, 6, 8, 8, 10, 10]
+    InclSecPeak: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+    UseLikelihood: 1
+    BkgFunc: [ 'kExpo', 'kExpo', 'kExpo', 'kExpo', 'kExpo', 'kExpo', 'kExpo', 'kExpo', 'kExpo', 'kExpo', 'kExpo', 'kExpo']
+    SgnFunc: [ 'kGaus', 'kGaus', 'kGaus', 'kGaus', 'kGaus', 'kGaus', 'kGaus', 'kGaus', 'kGaus', 'kGaus', 'kGaus', 'kGaus']
+
+pp5TeVFD:
+    Meson: 'Dplus'
+    FixSigma: 0
+    SigmaFile: ''
+    SigmaMultFactor: 1.
+    FixMean: 0
+    MeanFile: ''
+    PtMin: [ 1, 2, 3, 4, 5, 6, 7, 8, 10, 12]
+    PtMax: [ 2, 3, 4, 5, 6, 7, 8, 10, 12, 16]
+    MassMin: [ 1.74, 1.74, 1.74, 1.74, 1.74, 1.74, 1.74, 1.74, 1.74, 1.74] 
+    MassMax: [ 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00]
+    Rebin: [ 5, 5, 5, 5, 6, 6, 6, 6, 8, 8 ]
+    InclSecPeak: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ]
+    UseLikelihood: 1
+    BkgFunc: [ 'kExpo', 'kExpo', 'kExpo', 'kExpo', 'kExpo', 'kExpo', 'kExpo', 'kExpo', 'kExpo', 'kExpo']
+    SgnFunc: [ 'kGaus', 'kGaus', 'kGaus', 'kGaus', 'kGaus', 'kGaus', 'kGaus', 'kGaus', 'kGaus', 'kGaus']
+

--- a/utils/AnalysisUtils.py
+++ b/utils/AnalysisUtils.py
@@ -31,6 +31,7 @@ def ComputeEfficiency(recoCounts, genCounts, recoCountsError, genCountsError):
 
     return hTmpNum.GetBinContent(1), hTmpNum.GetBinError(1)
 
+
 def GetPromptFDYieldsAnalyticMinimisation(effPromptList, effFDList, rawYieldList, \
     effPromptUncList, effFDUncList, rawYieldUncList, precision=1.e-8, nMaxIter=100):
     '''

--- a/utils/AnalysisUtils.py
+++ b/utils/AnalysisUtils.py
@@ -1,0 +1,104 @@
+'''
+Script with miscellanea utils methods for the analysis
+'''
+
+import numpy as np
+from ROOT import TH1F # pylint: disable=import-error,no-name-in-module
+
+def ComputeEfficiency(recoCounts, genCounts, recoCountsError, genCountsError):
+    '''
+    method to compute efficiency
+
+    Parameters
+    ----------
+    - recoCounts: number of reconstructed D
+    - genCounts: number of genertated D
+    - recoCountsError: error on number of reconstructed D
+    - genCountsError: error on number of generated D
+
+    Returns
+    ----------
+    - efficiency, error on efficiency
+    '''
+
+    hTmpNum = TH1F('hTmpNum', '', 1, 0, 1)
+    hTmpDen = TH1F('hTmpDen', '', 1, 0, 1)
+    hTmpNum.SetBinContent(1, recoCounts)
+    hTmpDen.SetBinContent(1, genCounts)
+    hTmpNum.SetBinError(1, recoCountsError)
+    hTmpDen.SetBinError(1, genCountsError)
+    hTmpNum.Divide(hTmpNum, hTmpDen, 1., 1, 'B')
+
+    return hTmpNum.GetBinContent(1), hTmpNum.GetBinError(1)
+
+def GetPromptFDYieldsAnalyticMinimisation(effPromptList, effFDList, rawYieldList, \
+    effPromptUncList, effFDUncList, rawYieldUncList, precision=1.e-8, nMaxIter=100):
+    '''
+    method for retrieve prompt and FD corrected yields with an analytic system minimisation
+
+    Parameters
+    ----------
+
+    - effPromptList: list of efficiencies for prompt D
+    - effFDList: list of efficiencies for FD D
+    - rawYieldList: list of raw yields
+    - effPromptUncList: list of uncertainties on efficiencies for prompt D
+    - effFDUncList: list of uncertainties on efficiencies for FD D
+    - rawYieldUncList: list of uncertainties on raw yields
+    - precision (float, optional): target precision for minimisation procedure
+    - nMaxIter (int, optional): max number of iterations for minimisation procedure
+
+    Returns
+    ----------
+
+    - mCorrYield (numpy matrix): corrected yields (Nprompt, NFD)
+    - mCovariance (numpy matrix): covariance matrix for corrected yields
+    '''
+
+    nCutSets = len(effPromptList)
+
+    mRawYield = np.zeros(shape=(nCutSets, 1))
+    mEff = np.zeros(shape=(nCutSets, 2))
+    mWeights = np.zeros(shape=(nCutSets, nCutSets))
+
+    mCorrYield = np.zeros(shape=(2, 1))
+    mCorrYieldOld = np.zeros(shape=(2, 1))
+    mCovariance = np.zeros(shape=(2, 2))
+
+    for iCutSet, (rawYield, effPrompt, effFD) in enumerate(zip(rawYieldList, effPromptList, effFDList)):
+        mRawYield.itemset(iCutSet, rawYield)
+        mEff.itemset((iCutSet, 0), effPrompt)
+        mEff.itemset((iCutSet, 1), effFD)
+
+    mRawYield = np.matrix(mRawYield)
+    mEff = np.matrix(mEff)
+
+    for iIter in range(nMaxIter):
+        #covariances not taken into account in weight matrix at the moment
+        if iIter == 0:
+            mCorrYield.itemset(0, 10)
+            mCorrYield.itemset(1, 10000)
+        for iCutSet, (rawYieldUnc, effPromptUnc, effFDUnc) in enumerate(zip(\
+            rawYieldUncList, effPromptUncList, effFDUncList)):
+            mWeights.itemset((iCutSet, iCutSet), \
+                1. / (rawYieldUnc**2 + effPromptUnc**2 * mCorrYield.item(0) + effFDUnc**2 * mCorrYield.item(1)))
+
+        mWeights = np.matrix(mWeights)
+        mEffT = np.transpose(mEff)
+
+        mCovariance = (mEffT * mWeights) * mEff
+        mCovariance = np.linalg.inv(mCovariance)
+        if mCovariance.item(0, 0) < 1.e-36 or mCovariance.item(1, 1) < 1.e-36:
+            print("ERROR: Close to zero or negative diagonal element in covariance matrix:"
+                  "likely inversion failed, cannot proceed!")
+            return None, None
+
+        mCorrYield = mCovariance * (mEffT * mWeights) * mRawYield
+
+        if (mCorrYield.item(0)-mCorrYieldOld.item(0)) / mCorrYield.item(0) < precision and \
+            (mCorrYield.item(1)-mCorrYieldOld.item(1)) / mCorrYield.item(1) < precision:
+            break
+
+        mCorrYieldOld = np.copy(mCorrYield)
+
+    return mCorrYield, mCovariance


### PR DESCRIPTION
- add script for non-prompt fraction computation with data-driven approach
- add analysis utils script with methods for 1) efficiency computation 2) fprompt computation with analytic minimisation of system of equations corresponding to N different set of cuts
- add example of config files for non-prompt fraction and invariant-mass fits of D+ in pp@5TeV

Still to do: 
- consider correlation among set of cuts in anlytic minimisation