### PR TITLE
Fix bug in usage of cross-section prediction

### DIFF
--- a/ComputeCutVarPromptFrac.py
+++ b/ComputeCutVarPromptFrac.py
@@ -78,7 +78,6 @@ if compareToFc or compareToNb:
         f"{cutSetCfg['theorydriven']['predictions']['crosssec']['histonames']['feeddown']}_max_corr"))
 
     if compareToNb:
-        BR = cutSetCfg['theorydriven']['BR']
         sigmaMB = cutSetCfg['theorydriven']['sigmaMB']
 
 SetGlobalStyle(padleftmargin=0.15, padtopmargin=0.08, titleoffsetx=1., titleoffsety=1.4, opttitle=1, palette=kRainBow)
@@ -204,9 +203,9 @@ for iPt in range(hRawYields[0].GetNbinsX()):
     # cross sections from theory if comparison enabled
     if compareToFc or compareToNb:
         crossSecPrompt = [h.Integral(h.GetXaxis().FindBin(
-            ptMin*1.0001), h.GetXaxis().FindBin(ptMax*0.9999)) / (ptMax-ptMin) for h in hCrossSecPrompt]
+            ptMin*1.0001), h.GetXaxis().FindBin(ptMax*0.9999), 'width') / (ptMax-ptMin) for h in hCrossSecPrompt]
         crossSecFD = [h.Integral(h.GetXaxis().FindBin(
-            ptMin*1.0001), h.GetXaxis().FindBin(ptMax*0.9999)) / (ptMax-ptMin) for h in hCrossSecFD]
+            ptMin*1.0001), h.GetXaxis().FindBin(ptMax*0.9999), 'width') / (ptMax-ptMin) for h in hCrossSecFD]
 
         if compareToFc:
             gPromptFracFcVsCut.append(TGraphAsymmErrors(nSets))
@@ -292,7 +291,7 @@ for iPt in range(hRawYields[0].GetNbinsX()):
             gFDFracFcVsCut[iPt].SetPointError(iCutSet, 0.5, 0.5, fFDFc[0]-fFDFc[1], fFDFc[2]-fFDFc[0])
 
         if compareToNb:
-            fPromptNb = GetFractionNb(rawY, effP, effF, crossSecFD, ptMax-ptMin, 1., BR,
+            fPromptNb = GetFractionNb(rawY, effP, effF, crossSecFD, ptMax-ptMin, 1., 1.,
                                       hEv[iCutSet].GetBinContent(1), sigmaMB)
             fFDNb = [1-fPromptNb[0], 1-fPromptNb[2], 1-fPromptNb[1]] #inverse Nb method not reliable
 

--- a/ComputeDataDrivenCrossSection.py
+++ b/ComputeDataDrivenCrossSection.py
@@ -125,10 +125,10 @@ for iPt in range(hCrossSection.GetNbinsX()):
         effAcc = effAccPrompt
         frac = fPrompt
     else:
-        effAcc = hEffAccFD.GetBinContent(iPt+1)
+        effAcc = effAccFD
         frac = fFD
 
-    crossSec, crossSecUnc = ComputeCrossSection(rawYield, rawYieldUnc, effAcc, 1., ptMax-ptMin, 1., sigmaMB, nEv, BR)
+    crossSec, crossSecUnc = ComputeCrossSection(rawYield, rawYieldUnc, effAcc, frac, ptMax-ptMin, 1., sigmaMB, nEv, BR)
     hCrossSection.SetBinContent(iPt+1, crossSec * 1.e-6) # convert from pb to mub
     hCrossSection.SetBinError(iPt+1, crossSecUnc * 1.e-6) # convert from pb to mub
 

--- a/configfiles/datadrivenfprompt/config_Dplus_PromptFrac_pp5TeV.yml
+++ b/configfiles/datadrivenfprompt/config_Dplus_PromptFrac_pp5TeV.yml
@@ -1,11 +1,11 @@
 rawyields:
     inputdir: ../AnalysisNonPromptDpp2017/Dplus/outputs/rawyields
-    inputfiles: [ RawYieldsDplus_FD1dot1.root, RawYieldsDplus_FD1dot2.root, RawYieldsDplus_FD1dot3.root, RawYieldsDplus_FD1dot4.root, RawYieldsDplus_FD1dot5.root, RawYieldsDplus_FD1dot6.root, RawYieldsDplus_FD1dot7.root, RawYieldsDplus_FD1dot8.root, RawYieldsDplus_FD1dot9.root, RawYieldsDplus_FD2.root] #RawYieldsDplus_FDminus0dot3.root, RawYieldsDplus_FDminus0dot2.root, RawYieldsDplus_FDminus0dot1.root, RawYieldsDplus_FD0.root, RawYieldsDplus_FD0dot1.root, RawYieldsDplus_FD0dot2.root, RawYieldsDplus_FD0dot3.root, RawYieldsDplus_FD0dot4.root, RawYieldsDplus_FD0dot5.root, RawYieldsDplus_FD0dot6.root, RawYieldsDplus_FD0dot7.root, RawYieldsDplus_FD0dot8.root, RawYieldsDplus_FD0dot9.root, RawYieldsDplus_FD1.root, 
+    inputfiles: [ RawYieldsDplus_FD0.root, RawYieldsDplus_FD1.root, RawYieldsDplus_FD2.root, RawYieldsDplus_FD3.root, RawYieldsDplus_FD4.root, RawYieldsDplus_FD5.root, RawYieldsDplus_FD6.root, RawYieldsDplus_FD7.root, RawYieldsDplus_FD8.root, RawYieldsDplus_FD9.root, RawYieldsDplus_FD10.root, RawYieldsDplus_FD11.root, RawYieldsDplus_FD12.root, RawYieldsDplus_FD13.root, RawYieldsDplus_FD14.root, RawYieldsDplus_FD15.root, RawYieldsDplus_FD16.root, RawYieldsDplus_FD17.root, RawYieldsDplus_FD18.root, RawYieldsDplus_FD19.root, RawYieldsDplus_FD20.root ]
     histoname: hRawYields
 
 efficiencies:
     inputdir: ../AnalysisNonPromptDpp2017/Dplus/outputs/efficiency
-    inputfiles: [EffAccDplus_FD1dot1.root, EffAccDplus_FD1dot2.root, EffAccDplus_FD1dot3.root, EffAccDplus_FD1dot4.root, EffAccDplus_FD1dot5.root, EffAccDplus_FD1dot6.root, EffAccDplus_FD1dot7.root, EffAccDplus_FD1dot8.root, EffAccDplus_FD1dot9.root, EffAccDplus_FD2.root] #EffAccDplus_FDminus0dot3.root, EffAccDplus_FDminus0dot2.root, EffAccDplus_FDminus0dot1.root, EffAccDplus_FD0.root, EffAccDplus_FD0dot1.root, EffAccDplus_FD0dot2.root, EffAccDplus_FD0dot3.root, EffAccDplus_FD0dot4.root, EffAccDplus_FD0dot5.root, EffAccDplus_FD0dot6.root, EffAccDplus_FD0dot7.root, EffAccDplus_FD0dot8.root, EffAccDplus_FD0dot9.root, EffAccDplus_FD1.root,
+    inputfiles: [ EffAccDplus_FD0.root, EffAccDplus_FD1.root, EffAccDplus_FD2.root, EffAccDplus_FD3.root, EffAccDplus_FD4.root, EffAccDplus_FD5.root, EffAccDplus_FD6.root, EffAccDplus_FD7.root, EffAccDplus_FD8.root, EffAccDplus_FD9.root, EffAccDplus_FD10.root, EffAccDplus_FD11.root, EffAccDplus_FD12.root, EffAccDplus_FD13.root, EffAccDplus_FD14.root, EffAccDplus_FD15.root, EffAccDplus_FD16.root, EffAccDplus_FD17.root, EffAccDplus_FD18.root, EffAccDplus_FD19.root, EffAccDplus_FD20.root ]
     histonames:
         prompt: hAccEffPrompt
         feeddown: hAccEffFD
@@ -14,8 +14,8 @@ minimisation:
     correlated: true #true --> fully correlated, false --> fully uncorrelated        
 
 theorydriven:
-    enableFc: false
-    enableNb: true
+    enableFc: true
+    enableNb: false
     predictions:
         crosssec: 
             inputfile: models/D0DplusDstarPredictions_502TeV_y05_noYShift_all_191017_BDShapeCorrected.root
@@ -24,5 +24,4 @@ theorydriven:
                 feeddown: hDpluskpipifromBpred
         Raa: null   
     # below only needed for Nb
-    BR: 0.0898
     sigmaMB: 50.87e+9

--- a/optimisation/ScanSelectionsTree.py
+++ b/optimisation/ScanSelectionsTree.py
@@ -176,8 +176,8 @@ for iPt, (ptMin, ptMax) in enumerate(zip(ptMins, ptMaxs)):
     # cross section from theory
     ptBinCrossSecMin = hCrossSecPrompt.GetXaxis().FindBin(ptMin*1.0001)
     ptBinCrossSecMax = hCrossSecPrompt.GetXaxis().FindBin(ptMax*0.9999)
-    crossSecPrompt = hCrossSecPrompt.Integral(ptBinCrossSecMin, ptBinCrossSecMax) / (ptMax - ptMin)
-    crossSecFD = hCrossSecFD.Integral(ptBinCrossSecMin, ptBinCrossSecMax) / (ptMax - ptMin)
+    crossSecPrompt = hCrossSecPrompt.Integral(ptBinCrossSecMin, ptBinCrossSecMax, 'width') / (ptMax - ptMin)
+    crossSecFD = hCrossSecFD.Integral(ptBinCrossSecMin, ptBinCrossSecMax, 'width') / (ptMax - ptMin)
 
     # output histos
     hSignifVsRest.append(dict())
@@ -245,7 +245,8 @@ for iPt, (ptMin, ptMax) in enumerate(zip(ptMins, ptMaxs)):
 
         # expected signal
         expSignal = GetExpectedSignal(crossSecPrompt, ptMax-ptMin, 1., effTimesAccPrompt,
-                                      fPrompt[0], BR, 1., nExpEv, sigmaMB, Taa, RaaPrompt)
+                                      fPrompt[0], 1., 1., nExpEv, sigmaMB, Taa, RaaPrompt)
+        # BR already included in cross section
 
         # expected background
         if inputCfg['infiles']['background']['isMC']:

--- a/optimisation/config_Dplus_pp5TeV_Optimisation.yml
+++ b/optimisation/config_Dplus_pp5TeV_Optimisation.yml
@@ -45,7 +45,6 @@ predictions:
 
 nExpectedEvents: 950000000
 BR: 0.0898
-fractoD: 0.42
 sigmaMB: 50.87e+9 #pb
 Taa: 1.
 


### PR DESCRIPTION
@fcatalan92 @stefanopolitano. The bug was due to the fact that the FONLL cross sections from the ROOT files are multiplied by the branching ratio. This bug affected:
- signal estimation
- prompt / feed-down fraction with Nb method