### PR TITLE
Add possibility to fix peak width to input value +- uncertainty

### DIFF
--- a/GetRawYieldsDplusDs.py
+++ b/GetRawYieldsDplusDs.py
@@ -305,8 +305,19 @@ for iPt, (hM, ptMin, ptMax, reb, sgn, bkg, secPeak, massMin, massMax) in enumera
             massFitter[iPt].SetInitialGaussianMean(massForFit)
 
         if fitConfig[cent]['FixSigma']:
-            massFitter[iPt].SetFixGaussianSigma(
-                hSigmaToFix.GetBinContent(iPt+1)*fitConfig[cent]['SigmaMultFactor'])
+            if isinstance(fitConfig[cent]['SigmaMultFactor'], float) or \
+                isinstance(fitConfig[cent]['SigmaMultFactor'], int):
+                massFitter[iPt].SetFixGaussianSigma(
+                    hSigmaToFix.GetBinContent(iPt+1)*fitConfig[cent]['SigmaMultFactor'])
+            else:
+                if fitConfig[cent]['SigmaMultFactor'] == 'MinusUnc':
+                    massFitter[iPt].SetFixGaussianSigma(
+                        hSigmaToFix.GetBinContent(iPt+1)-hSigmaToFix.GetBinError(iPt+1))
+                elif fitConfig[cent]['SigmaMultFactor'] == 'PlusUnc':
+                    massFitter[iPt].SetFixGaussianSigma(
+                        hSigmaToFix.GetBinContent(iPt+1)+hSigmaToFix.GetBinError(iPt+1))
+                else:
+                    print('WARNING: impossible to fix sigma! Wrong mult factor set in config file!')
 
         if secPeak and mesonName == 'Ds':
             # TODO: add possibility to fix D+ peak to sigmaMC(D+)/sigmaMC(Ds+)*sigmaData(Ds+)


### PR DESCRIPTION
the fix sigma +- uncertainty can be set in the config file, by selecting 

https://github.com/DmesonAnalysers/DmesonAnalysis/blob/7d934e2a945db737ae9e653443f2c49e9d0c4a09/configfiles/fit/config_Dplus_Fit_pp5TeV.yml#L20

equal to ```1``` instead of ```0``` and replacing

https://github.com/DmesonAnalysers/DmesonAnalysis/blob/7d934e2a945db737ae9e653443f2c49e9d0c4a09/configfiles/fit/config_Dplus_Fit_pp5TeV.yml#L22

with either
```yaml
SigmaMultFactor: MinusUnc
```
or
```yaml
SigmaMultFactor: PlusUnc
```