### PR TITLE
Add code for femtoscopy studies

### DIFF
--- a/GetRawYieldsDplusDs.py
+++ b/GetRawYieldsDplusDs.py
@@ -8,8 +8,8 @@ import argparse
 import ctypes
 import numpy as np
 import yaml
-from ROOT import TFile, TCanvas, TH1D, TH1F, TF1, TDatabasePDG, AliHFInvMassFitter, AliVertexingHFUtils  # pylint: disable=import-error,no-name-in-module
-from ROOT import gROOT, gPad, kBlack, kRed, kFullCircle, kFullSquare  # pylint: disable=import-error,no-name-in-module
+from ROOT import TFile, TCanvas, TH1D, TH1F, TF1, TDatabasePDG, TDirectoryFile, AliHFInvMassFitter, AliVertexingHFUtils # pylint: disable=import-error,no-name-in-module
+from ROOT import gROOT, gPad, kBlack, kRed, kFullCircle, kFullSquare # pylint: disable=import-error,no-name-in-module
 from utils.StyleFormatter import SetGlobalStyle, SetObjectStyle, DivideCanvas
 from utils.FitUtils import SingleGaus, DoubleGaus, DoublePeakSingleGaus, DoublePeakDoubleGaus
 
@@ -112,59 +112,54 @@ if fitConfig[cent]['FixSigma']:
     infileSigma = TFile.Open(fitConfig[cent]['SigmaFile'])
     if not infileSigma:
         sys.exit()
-    hSigmaToFix = infileSigma.Get("hRawYieldsSigma")
+    hSigmaToFix = infileSigma.Get('hRawYieldsSigma')
     if hSigmaToFix.GetNbinsX() != nPtBins:
-        print("WARNING: Different number of bins for this analysis and histo for fix sigma")
+        print('WARNING: Different number of bins for this analysis and histo for fix sigma')
 
 if fitConfig[cent]['FixMean']:
     infileMean = TFile.Open(fitConfig[cent]['MeanFile'])
     if not infileMean or not infileMean.IsOpen():
         sys.exit()
-    hMeanToFix = infileMean.Get("hRawYieldsMean")
+    hMeanToFix = infileMean.Get('hRawYieldsMean')
     if hMeanToFix.GetNbinsX() != nPtBins:
-        print("WARNING: Different number of bins for this analysis and histo for fix mean")
+        print('WARNING: Different number of bins for this analysis and histo for fix mean')
 
-hRawYields = TH1D('hRawYields', ';#it{p}_{T} (GeV/#it{c});raw yield', nPtBins, np.asarray(ptLims, 'd'))
-hRawYieldsSigma = TH1D('hRawYieldsSigma', ';#it{p}_{T} (GeV/#it{c});width (GeV/#it{c}^{2})', \
-    nPtBins, np.asarray(ptLims, 'd'))
-hRawYieldsSigma2 = TH1D('hRawYieldsSigma2', ';#it{p}_{T} (GeV/#it{c});width (GeV/#it{c}^{2})', \
-    nPtBins, np.asarray(ptLims, 'd'))
-hRawYieldsMean = TH1D('hRawYieldsMean', ';#it{p}_{T} (GeV/#it{c});mean (GeV/#it{c}^{2})', \
-    nPtBins, np.asarray(ptLims, 'd'))
-hRawYieldsFracGaus2 = TH1D('hRawYieldsFracGaus2', ';#it{p}_{T} (GeV/#it{c});second-gaussian fraction', \
-    nPtBins, np.asarray(ptLims, 'd'))
-hRawYieldsSignificance = TH1D('hRawYieldsSignificance', ';#it{p}_{T} (GeV/#it{c});significance (3#sigma)', \
-    nPtBins, np.asarray(ptLims, 'd'))
-hRawYieldsSoverB = TH1D('hRawYieldsSoverB', ';#it{p}_{T} (GeV/#it{c});S/B (3#sigma)', nPtBins, np.asarray(ptLims, 'd'))
-hRawYieldsSignal = TH1D('hRawYieldsSignal', ';#it{p}_{T} (GeV/#it{c});Signal (3#sigma)', \
-    nPtBins, np.asarray(ptLims, 'd'))
-hRawYieldsBkg = TH1D('hRawYieldsBkg', ';#it{p}_{T} (GeV/#it{c});Background (3#sigma)', \
-    nPtBins, np.asarray(ptLims, 'd'))
-hRawYieldsChiSquare = TH1D('hRawYieldsChiSquare', ';#it{p}_{T} (GeV/#it{c});#chi^{2}/#it{ndf}', \
-    nPtBins, np.asarray(ptLims, 'd'))
-hRawYieldsSecPeak = TH1D('hRawYieldsSecPeak', ';#it{p}_{T} (GeV/#it{c});raw yield second peak', \
-    nPtBins, np.asarray(ptLims, 'd'))
-hRawYieldsMeanSecPeak = TH1D('hRawYieldsMeanSecPeak', ';#it{p}_{T} (GeV/#it{c});mean second peak (GeV/#it{c}^{2})', \
-    nPtBins, np.asarray(ptLims, 'd'))
-hRawYieldsSigmaSecPeak = TH1D('hRawYieldsSigmaSecPeak', \
-    ';#it{p}_{T} (GeV/#it{c});width second peak (GeV/#it{c}^{2})', nPtBins, np.asarray(ptLims, 'd'))
-hRawYieldsSignificanceSecPeak = TH1D('hRawYieldsSignificanceSecPeak', \
-    ';#it{p}_{T} (GeV/#it{c});signficance second peak (3#sigma)', nPtBins, np.asarray(ptLims, 'd'))
-hRawYieldsSigmaRatioSecondFirstPeak = TH1D('hRawYieldsSigmaRatioSecondFirstPeak', \
-    ';#it{p}_{T} (GeV/#it{c});width second peak / width first peak', nPtBins, np.asarray(ptLims, 'd'))
-hRawYieldsSoverBSecPeak = TH1D('hRawYieldsSoverBSecPeak', ';#it{p}_{T} (GeV/#it{c});S/B second peak (3#sigma)', \
-    nPtBins, np.asarray(ptLims, 'd'))
-hRawYieldsSignalSecPeak = TH1D('hRawYieldsSignalSecPeak', ';#it{p}_{T} (GeV/#it{c});Signal second peak (3#sigma)', \
-    nPtBins, np.asarray(ptLims, 'd'))
-hRawYieldsBkgSecPeak = TH1D('hRawYieldsBkgSecPeak', ';#it{p}_{T} (GeV/#it{c});Background second peak (3#sigma)', \
-    nPtBins, np.asarray(ptLims, 'd'))
-hRawYieldsTrue = TH1D('hRawYieldsTrue', ';#it{p}_{T} (GeV/#it{c});true signal', nPtBins, np.asarray(ptLims, 'd'))
-hRawYieldsSecPeakTrue = TH1D('hRawYieldsSecPeakTrue', ';#it{p}_{T} (GeV/#it{c});true signal second peak', \
-    nPtBins, np.asarray(ptLims, 'd'))
-hRelDiffRawYieldsFitTrue = TH1D('hRelDiffRawYieldsFitTrue', \
-    ';#it{p}_{T} (GeV/#it{c}); (Y_{fit} - Y_{true}) / Y_{true}', nPtBins, np.asarray(ptLims, 'd'))
-hRelDiffRawYieldsSecPeakFitTrue = TH1D('hRelDiffRawYieldsSecPeakFitTrue', \
-    ';#it{p}_{T} (GeV/#it{c});(Y_{fit} - Y_{true}) / Y_{true} second peak', nPtBins, np.asarray(ptLims, 'd'))
+ptBinsArr = np.asarray(ptLims, 'd')
+ptTit = 'it{p}_{T} (GeV/#it{c})'
+
+hRawYields = TH1D('hRawYields', f'{ptTit};raw yield', nPtBins, ptBinsArr)
+hRawYieldsSigma = TH1D('hRawYieldsSigma', f'{ptTit};width (GeV/#it{{c}}^{{2}})', nPtBins, ptBinsArr)
+hRawYieldsSigma2 = TH1D('hRawYieldsSigma2', f'{ptTit};width (GeV/#it{{c}}^{{2}})', nPtBins, ptBinsArr)
+hRawYieldsMean = TH1D('hRawYieldsMean', f'{ptTit};mean (GeV/#it{{c}}^{{2}})', nPtBins, ptBinsArr)
+hRawYieldsFracGaus2 = TH1D('hRawYieldsFracGaus2', f'{ptTit};second-gaussian fraction', nPtBins, ptBinsArr)
+hRawYieldsSignificance = TH1D('hRawYieldsSignificance', f'{ptTit};significance (3#sigma)', nPtBins, ptBinsArr)
+hRawYieldsSoverB = TH1D('hRawYieldsSoverB', f'{ptTit};S/B (3#sigma)', nPtBins, ptBinsArr)
+hRawYieldsSignal = TH1D('hRawYieldsSignal', f'{ptTit};Signal (3#sigma)', nPtBins, ptBinsArr)
+hRawYieldsBkg = TH1D('hRawYieldsBkg', f'{ptTit};Background (3#sigma)', nPtBins, ptBinsArr)
+hRawYieldsChiSquare = TH1D('hRawYieldsChiSquare', f'{ptTit};#chi^{{2}}/#it{{ndf}}', nPtBins, ptBinsArr)
+hRawYieldsSecPeak = TH1D('hRawYieldsSecPeak', f'{ptTit};raw yield second peak', nPtBins, ptBinsArr)
+hRawYieldsMeanSecPeak = TH1D('hRawYieldsMeanSecPeak', f'{ptTit};mean second peak (GeV/#it{{c}}^{{2}})',
+                             nPtBins, ptBinsArr)
+hRawYieldsSigmaSecPeak = TH1D('hRawYieldsSigmaSecPeak', f'{ptTit};width second peak (GeV/#it{{c}}^{{2}})',
+                              nPtBins, ptBinsArr)
+hRawYieldsSignificanceSecPeak = TH1D('hRawYieldsSignificanceSecPeak',
+                                     f'{ptTit};signficance second peak (3#sigma)', nPtBins, ptBinsArr)
+hRawYieldsSigmaRatioSecondFirstPeak = TH1D('hRawYieldsSigmaRatioSecondFirstPeak',
+                                           f'{ptTit};width second peak / width first peak', nPtBins, ptBinsArr)
+hRawYieldsSoverBSecPeak = TH1D('hRawYieldsSoverBSecPeak', f'{ptTit};S/B second peak (3#sigma)',
+                               nPtBins, ptBinsArr)
+hRawYieldsSignalSecPeak = TH1D('hRawYieldsSignalSecPeak', f'{ptTit};Signal second peak (3#sigma)',
+                               nPtBins, ptBinsArr)
+hRawYieldsBkgSecPeak = TH1D('hRawYieldsBkgSecPeak', f'{ptTit};Background second peak (3#sigma)',
+                            nPtBins, ptBinsArr)
+hRawYieldsTrue = TH1D('hRawYieldsTrue', f'{ptTit};true signal', nPtBins, ptBinsArr)
+hRawYieldsSecPeakTrue = TH1D('hRawYieldsSecPeakTrue', f'{ptTit};true signal second peak',
+                             nPtBins, ptBinsArr)
+hRelDiffRawYieldsFitTrue = TH1D('hRelDiffRawYieldsFitTrue', f'{ptTit}; (Y_{{fit}} - Y_{{true}}) / Y_{{true}}',
+                                nPtBins, ptBinsArr)
+hRelDiffRawYieldsSecPeakFitTrue = TH1D('hRelDiffRawYieldsSecPeakFitTrue',
+                                       f'{ptTit};(Y_{{fit}} - Y_{{true}}) / Y_{{true}} second peak',
+                                       nPtBins, ptBinsArr)
 
 SetObjectStyle(hRawYields, color=kBlack, markerstyle=kFullCircle)
 SetObjectStyle(hRawYieldsSigma, color=kBlack, markerstyle=kFullCircle)
@@ -189,6 +184,25 @@ SetObjectStyle(hRawYieldsSecPeakTrue, color=kRed, markerstyle=kFullSquare)
 SetObjectStyle(hRelDiffRawYieldsFitTrue, color=kRed, markerstyle=kFullSquare)
 SetObjectStyle(hRelDiffRawYieldsSecPeakFitTrue, color=kRed, markerstyle=kFullSquare)
 
+# additional S, B, S/B, and significance histos for different Nsigma values (filled only in case of data)
+nSigma4SandB = [1.5, 1.75, 2., 2.25, 2.5, 2.75]
+hRawYieldsSignalDiffSigma, hRawYieldsBkgDiffSigma, hRawYieldsSoverBDiffSigma, \
+    hRawYieldsSignifDiffSigma = ([] for _ in range(4))
+
+for iS, sigma in enumerate(nSigma4SandB):
+    hRawYieldsSignalDiffSigma.append(TH1D(f'hRawYieldsSignal_{sigma:0.2f}sigma',
+                                          f';{ptTit};Signal ({sigma:0.2f}#sigma)', nPtBins, ptBinsArr))
+    hRawYieldsBkgDiffSigma.append(TH1D(f'hRawYieldsBkg_{sigma:0.2f}sigma',
+                                       f';{ptTit};Background ({sigma:0.2f}#sigma)', nPtBins, ptBinsArr))
+    hRawYieldsSoverBDiffSigma.append(TH1D(f'hRawYieldsSoverB_{sigma:0.2f}sigma',
+                                          f';{ptTit};S/B ({sigma:0.2f}#sigma)', nPtBins, ptBinsArr))
+    hRawYieldsSignifDiffSigma.append(TH1D(f'hRawYieldsSignif_{sigma:0.2f}sigma',
+                                          f';{ptTit};significance ({sigma:0.2f}#sigma)', nPtBins, ptBinsArr))
+    SetObjectStyle(hRawYieldsSignalDiffSigma[iS], color=kBlack, markerstyle=kFullCircle)
+    SetObjectStyle(hRawYieldsBkgDiffSigma[iS], color=kBlack, markerstyle=kFullCircle)
+    SetObjectStyle(hRawYieldsSoverBDiffSigma[iS], color=kBlack, markerstyle=kFullCircle)
+    SetObjectStyle(hRawYieldsSignifDiffSigma[iS], color=kBlack, markerstyle=kFullCircle)
+
 # fit histos
 massDplus = TDatabasePDG.Instance().GetParticle(411).Mass()
 massDs = TDatabasePDG.Instance().GetParticle(431).Mass()
@@ -198,9 +212,9 @@ canvSizes = [1920, 1080]
 if nPtBins == 1:
     canvSizes = [500, 500]
 
-cMass = TCanvas("cMass", "cMass", canvSizes[0], canvSizes[1])
+cMass = TCanvas('cMass', 'cMass', canvSizes[0], canvSizes[1])
 DivideCanvas(cMass, nPtBins)
-cResiduals = TCanvas("cResiduals", "cResiduals", canvSizes[0], canvSizes[1])
+cResiduals = TCanvas('cResiduals', 'cResiduals', canvSizes[0], canvSizes[1])
 DivideCanvas(cResiduals, nPtBins)
 
 massFitter = []
@@ -212,9 +226,9 @@ for iPt, (hM, ptMin, ptMax, reb, sgn, bkg, secPeak, massMin, massMax) in enumera
     AliVertexingHFUtils.RebinHisto(hM, reb).Copy(hMassForFit[iPt]) #to cast TH1D to TH1F
     hMassForFit[iPt].SetDirectory(0)
     hMassForFit[iPt].SetTitle(
-        f"{ptMin:0.1f} < #it{{p}}_{{T}} < {ptMax:0.1f} GeV/#it{{c}};{massAxisTit};"
-        f"Counts per {hMassForFit[iPt].GetBinWidth(1)*1000:.0f} MeV/#it{{c}}^{{2}}")
-    hMassForFit[iPt].SetName(f"MassForFit{iPt}")
+        f'{ptMin:0.1f} < #it{{p}}_{{T}} < {ptMax:0.1f} GeV/#it{{c}};{massAxisTit};'
+        f'Counts per {hMassForFit[iPt].GetBinWidth(1)*1000:.0f} MeV/#it{{c}}^{{2}}')
+    hMassForFit[iPt].SetName(f'MassForFit{iPt}')
     if nPtBins < 15:
         markerSize = 1.
     else:
@@ -228,10 +242,10 @@ for iPt, (hM, ptMin, ptMax, reb, sgn, bkg, secPeak, massMin, massMax) in enumera
 
         if sgn == AliHFInvMassFitter.kGaus:
             if not (secPeak and mesonName == 'Ds'):
-                massFunc = TF1("massFunc{0}".format(iPt), SingleGaus, massMin, massMax, 3)
+                massFunc = TF1(f'massFunc{iPt}', SingleGaus, massMin, massMax, 3)
                 massFunc.SetParameters(hMassForFit[iPt].Integral()*hMassForFit[iPt].GetBinWidth(1), massForFit, 0.010)
             else:
-                massFunc = TF1("massFunc{0}".format(iPt), DoublePeakSingleGaus, massMin, massMax, 6)
+                massFunc = TF1(f'massFunc{iPt}', DoublePeakSingleGaus, massMin, massMax, 6)
                 massFunc.SetParameters(hMassForFit[iPt].Integral()*hMassForFit[iPt].GetBinWidth(1), massForFit, 0.010, \
                     hMassForFit[iPt].Integral()*hMassForFit[iPt].GetBinWidth(1), massDplus, 0.010)
                 parRawYieldSecPeak = 3
@@ -242,11 +256,11 @@ for iPt, (hM, ptMin, ptMax, reb, sgn, bkg, secPeak, massMin, massMax) in enumera
             parSigma2 = 3
             parFrac2Gaus = 4
             if not (secPeak and mesonName == 'Ds'):
-                massFunc = TF1("massFunc{0}".format(iPt), DoubleGaus, massMin, massMax, 5)
+                massFunc = TF1(f'massFunc{iPt}', DoubleGaus, massMin, massMax, 5)
                 massFunc.SetParameters(hMassForFit[iPt].Integral()*hMassForFit[iPt].GetBinWidth(1), massForFit, \
                     0.010, 0.030, 0.9)
             else:
-                massFunc = TF1("massFunc{0}".format(iPt), DoublePeakDoubleGaus, massMin, massMax, 8)
+                massFunc = TF1(f'massFunc{iPt}', DoublePeakDoubleGaus, massMin, massMax, 8)
                 massFunc.SetParameters(hMassForFit[iPt].Integral()*hMassForFit[iPt].GetBinWidth(1), massForFit, \
                     0.010, 0.030, 0.9, hMassForFit[iPt].Integral()*hMassForFit[iPt].GetBinWidth(1), massDplus, 0.010)
                 parRawYieldSecPeak = 5
@@ -464,7 +478,7 @@ for iPt, (hM, ptMin, ptMax, reb, sgn, bkg, secPeak, massMin, massMax) in enumera
     cResiduals.Update()
 
 #save output histos
-outFile = TFile(args.outFileName, "recreate")
+outFile = TFile(args.outFileName, 'recreate')
 cMass.Write()
 if not args.isMC:
     cResiduals.Write()
@@ -493,11 +507,21 @@ hRawYieldsSecPeakTrue.Write()
 hRelDiffRawYieldsFitTrue.Write()
 hRelDiffRawYieldsSecPeakFitTrue.Write()
 hEv.Write()
+if not args.isMC:
+    dirSB = TDirectoryFile('SandBDiffNsigma', 'SandBDiffNsigma')
+    dirSB.Write()
+    dirSB.cd()
+    for iS, _ in enumerate(nSigma4SandB):
+        hRawYieldsSignalDiffSigma[iS].Write()
+        hRawYieldsBkgDiffSigma[iS].Write()
+        hRawYieldsSoverBDiffSigma[iS].Write()
+        hRawYieldsSignifDiffSigma[iS].Write()
+    dirSB.Close()
 outFile.Close()
 
 outFileNamePDF = args.outFileName.replace('.root', '.pdf')
 cMass.SaveAs(outFileNamePDF)
-outFileNamePDF = args.outFileName.replace(".root", "_Residuals.pdf")
+outFileNamePDF = args.outFileName.replace('.root', '_Residuals.pdf')
 cResiduals.SaveAs(outFileNamePDF)
 
 if not args.batch:

--- a/femto/GetPurityVsKstar.py
+++ b/femto/GetPurityVsKstar.py
@@ -1,0 +1,270 @@
+'''
+python script for the evaluation of the D-meson S/B as a function of k*
+'''
+
+import sys
+import os
+import argparse
+import ctypes
+import yaml
+from ROOT import TFile, TCanvas, TGraphAsymmErrors, TLatex, TF1, TH1F, TGaxis, TLegend, TDirectoryFile, gPad, gRandom # pylint: disable=import-error,no-name-in-module
+from ROOT import kRed, kAzure, kBlack, kOpenCircle # pylint: disable=import-error,no-name-in-module
+sys.path.append('..')
+from utils.StyleFormatter import SetGlobalStyle, SetObjectStyle # pylint: disable=import-error,wrong-import-position
+
+parser = argparse.ArgumentParser(description='Arguments to pass')
+parser.add_argument('cfgFileName', metavar='text', default='cfgFileName.yml',
+                    help='yaml config file name')
+args = parser.parse_args()
+
+with open(args.cfgFileName, 'r') as ymlFile:
+    cfg = yaml.load(ymlFile, yaml.FullLoader)
+
+rawYiedlFileName = cfg['rawyields']['filename']
+SoverBHistoName = cfg['rawyields']['histoname']
+inFileName = cfg['input']['filename']
+suffix = cfg['input']['suffix']
+prefix = cfg['input']['prefix']
+outDirName = cfg['output']['directory']
+outSuffix = cfg['output']['suffix']
+addTDirectory = cfg['output']['addTDirectory']
+
+# setting global style
+SetGlobalStyle(padbottommargin=0.13, padtopmargin=0.075, titleoffsety=1.2, maxdigits=2)
+
+# load S/B histo
+inFile = TFile.Open(rawYiedlFileName)
+hSoverB = inFile.Get(SoverBHistoName)
+hSoverB.SetDirectory(0)
+hSoverB.SetTitle(';#it{p}_{T}(D^{#pm}) (GeV/#it{c});S/B')
+ptMax = hSoverB.GetXaxis().GetBinUpEdge(hSoverB.GetNbinsX())
+SetObjectStyle(hSoverB)
+inFile.Close()
+
+# load corr histos
+corrNames = ['Particle0_Particle2', 'Particle1_Particle3', 'Particle0_Particle3', 'Particle1_Particle2']
+corrTitles = {'Particle0_Particle2': 'p - D^{+}',
+              'Particle0_Particle3': 'p - D^{#font[122]{-}}',
+              'Particle1_Particle2': '#bar{p} - D^{+}',
+              'Particle1_Particle3': '#bar{p} - D^{#font[122]{-}}'}
+
+inFile = TFile.Open(inFileName)
+listName = f'{prefix}_CharmFemto_ResultQA{suffix}/{prefix}_CharmFemto_ResultQA{suffix}'
+inList = inFile.Get(listName)
+
+kStarDelta = 0.2
+kStarMins = [iK * kStarDelta for iK in range(15)]
+kStarMaxs = [(iK+1) * kStarDelta for iK in range(15)]
+
+hSEPairVsPtVsKstar, hSEPairVsPt = {}, {}
+for corrName in corrNames:
+    listCorr = inList.FindObject(f'QA_{corrName}')
+    hSEPairVsPtVsKstar[corrName], hSEPairVsPt[corrName] = [], []
+    for kStarMin, kStarMax in zip(kStarMins, kStarMaxs):
+        hSEPairVsPtVsKstar[corrName].append(listCorr.FindObject(f'KstarPtSEPartTwo_{corrName}'))
+        hSEPairVsPtVsKstar[corrName][-1].SetDirectory(0)
+        kStarMaxBin = hSEPairVsPtVsKstar[corrName][-1].GetXaxis().FindBin(kStarMax)
+        # assuming constant pT binning
+        ptRebin = round(hSoverB.GetBinWidth(1) / hSEPairVsPtVsKstar[corrName][-1].GetYaxis().GetBinWidth(1))
+        hSEPairVsPt[corrName].append(
+            hSEPairVsPtVsKstar[corrName][-1].ProjectionY(f'hSEPairVsPt_{corrName}', 1, kStarMaxBin))
+        hSEPairVsPt[corrName][-1].SetDirectory(0)
+        hSEPairVsPt[corrName][-1].Rebin(ptRebin)
+        SetObjectStyle(hSEPairVsPt[corrName][-1], color=kRed+1, markerstyle=kOpenCircle, fillstyle=0)
+        if 'Particle2' in corrName:
+            hSEPairVsPt[corrName][-1].SetTitle(';#it{p}_{T}(D^{+}) (GeV/#it{c});SE pairs')
+        else:
+            hSEPairVsPt[corrName][-1].SetTitle(';#it{p}_{T}(D^{#font[122]{-}}) (GeV/#it{c});SE pairs')
+        hSEPairVsPt[corrName][-1].GetXaxis().SetTitleSize(0.05)
+        hSEPairVsPt[corrName][-1].GetXaxis().SetLabelSize(0.05)
+        hSEPairVsPt[corrName][-1].GetYaxis().SetTitleSize(0.05)
+        hSEPairVsPt[corrName][-1].GetYaxis().SetLabelSize(0.05)
+        hSEPairVsPt[corrName][-1].GetYaxis().SetDecimals()
+        ptMaxPair = hSEPairVsPt[corrName][-1].GetXaxis().GetBinUpEdge(hSEPairVsPt[corrName][-1].GetNbinsX())
+        if ptMaxPair < ptMax:
+            ptMax = ptMaxPair
+inFile.Close()
+
+for corrName in ['Particle0_Particle2_plus_Particle1_Particle3', 'Particle0_Particle3_plus_Particle1_Particle2']:
+    corrNamePart = corrName.split('_plus_')
+    hSEPairVsPt[corrName] = []
+    for iK, (kStarMin, kStarMax) in enumerate(zip(kStarMins, kStarMaxs)):
+        hSEPairVsPt[corrName].append(hSEPairVsPt[corrNamePart[0]][iK].Clone(f'hSEPairVsPt_{corrName}'))
+        hSEPairVsPt[corrName][iK].Add(hSEPairVsPt[corrNamePart[1]][iK])
+        hSEPairVsPt[corrName][iK].SetDirectory(0)
+        hSEPairVsPt[corrName][iK].SetTitle(';#it{p}_{T}(D^{#pm}) (GeV/#it{c});SE pairs')
+        if iK == 0:
+            corrTitles[corrName] = corrTitles[corrNamePart[0]] + ' #oplus ' + corrTitles[corrNamePart[1]]
+
+# compute < S/B >
+gAverageSoverB, gSoverBAvPt = {}, {}
+for corrName in ['Particle0_Particle2_plus_Particle1_Particle3', 'Particle0_Particle3_plus_Particle1_Particle2']:
+    if corrName == 'Particle0_Particle2_plus_Particle1_Particle3':
+        suffix = 'DpPr'
+    else:
+        suffix = 'DmPr'
+    gAverageSoverB[corrName] = TGraphAsymmErrors(0)
+    gAverageSoverB[corrName].SetNameTitle(f'gAverageSoverB_{suffix}', ';#it{k}* (GeV/#it{c}); #LT S/B #GT')
+    gSoverBAvPt[corrName] = TGraphAsymmErrors(0)
+    gSoverBAvPt[corrName].SetNameTitle(f'gSoverBAvPt_{suffix}',
+                                       ';#it{k}* (GeV/#it{c}); S/B (#LT #it{p}_{T}(D^{#pm}) #GT)')
+    SetObjectStyle(gSoverBAvPt[corrName])
+    SetObjectStyle(gAverageSoverB[corrName], color=kRed+1, fillstyle=0, markerstyle=kOpenCircle)
+
+    hDistrAvSoverB = TH1F('hDistrAvSoverB', '', 100, 0., hSoverB.GetMaximum())
+    for iK, (kStarMin, kStarMax) in enumerate(zip(kStarMins, kStarMaxs)):
+        weighAv, totCounts = 0., 0.
+        hDistrAvSoverB.Reset()
+        for iGen in range(100): # estimate uncertainty due to uncertainty on weights
+            weighAvSmeared, totCountsSmeared = 0., 0.
+            for iPt in range(hSoverB.GetXaxis().FindBin(ptMax)):
+                ptCent = hSoverB.GetBinCenter(iPt+1)
+                ptBinPair = hSEPairVsPt[corrName][iK].GetXaxis().FindBin(ptCent)
+                nPairs = hSEPairVsPt[corrName][iK].GetBinContent(ptBinPair)
+                nPairsSmeared = gRandom.PoissonD(hSEPairVsPt[corrName][iK].GetBinContent(ptBinPair))
+                weighAvSmeared += hSoverB.GetBinContent(iPt+1) * nPairsSmeared
+                totCountsSmeared += nPairsSmeared
+                if iGen == 0:
+                    weighAv += hSoverB.GetBinContent(iPt+1) * nPairs
+                    totCounts += nPairs
+            hDistrAvSoverB.Fill(weighAvSmeared/totCountsSmeared)
+
+        weighAv /= totCounts
+        weighAvUnc = hDistrAvSoverB.GetRMS()
+
+        avPt = hSEPairVsPt[corrName][iK].GetMean()
+        avPtUnc = hSEPairVsPt[corrName][iK].GetMeanError()
+        # fit data points around mean value
+        fSoverB = TF1(f'fSoverB_kstar{iK}', 'pol2', 0., 10.)
+        fSoverB.SetLineColor(kAzure+4)
+        hSoverB.Fit(f'fSoverB_kstar{iK}', 'Q')
+
+        kStarCent = (kStarMax + kStarMin) / 2
+        gAverageSoverB[corrName].SetPoint(iK, kStarCent, weighAv)
+        gSoverBAvPt[corrName].SetPoint(iK, kStarCent, fSoverB.Eval(avPt))
+        gAverageSoverB[corrName].SetPointError(iK, kStarDelta/2, kStarDelta/2, weighAvUnc, weighAvUnc)
+        gSoverBAvPt[corrName].SetPointError(iK, kStarDelta/2, kStarDelta/2,
+                                            fSoverB.Eval(avPt)-fSoverB.Eval(avPt-avPtUnc),
+                                            fSoverB.Eval(avPt)-fSoverB.Eval(avPt+avPtUnc))
+
+# plots
+leg = TLegend(0.18, 0.7, 0.5, 0.85)
+leg.SetTextSize(0.045)
+leg.SetBorderSize(0)
+leg.SetFillStyle(0)
+leg.AddEntry(gAverageSoverB[corrName], 'weighted average', 'lp')
+leg.AddEntry(gSoverBAvPt[corrName], 'S/B (#LT #it{p}_{T}(D^{#pm}) #GT) - pol2 parametrisation', 'lp')
+
+cSoverBvsKstar = TCanvas('cSoverBvsKstar', '', 1000, 500)
+cSoverBvsKstar.Divide(2, 1)
+for iPad, corrName in enumerate(gAverageSoverB):
+    cSoverBvsKstar.cd(iPad+1).DrawFrame(0., 0., 3., hSoverB.GetMaximum()*1.2, ';#it{k}* (GeV/#it{c});#LT S/B #GT')
+    gAverageSoverB[corrName].Draw('p')
+    gSoverBAvPt[corrName].Draw('p')
+    leg.Draw()
+cSoverBvsKstar.Modified()
+cSoverBvsKstar.Update()
+
+info = TLatex()
+info.SetTextColor(kBlack)
+info.SetTextSize(0.045)
+info.SetTextFont(42)
+info.SetNDC()
+
+padOrder = {'Particle0_Particle2': 1,
+            'Particle1_Particle3': 2,
+            'Particle0_Particle2_plus_Particle1_Particle3': 3,
+            'Particle0_Particle3': 4,
+            'Particle1_Particle2': 5,
+            'Particle0_Particle3_plus_Particle1_Particle2': 6}
+
+cSEDistr = TCanvas('cSEDistr', '', 1200, 900)
+cSEDistr.Divide(3, 2)
+for corrName in hSEPairVsPt:
+    cSEDistr.cd(padOrder[corrName])
+    hSEPairVsPt[corrName][0].GetYaxis().SetRangeUser(0., hSEPairVsPt[corrName][0].GetMaximum()*2)
+    hSEPairVsPt[corrName][0].DrawCopy('e')
+    info.DrawLatex(0.2, 0.86, corrTitles[corrName])
+    DName = ''
+    if 'Particle2' in corrName and 'Particle3' in corrName:
+        DName = 'D^{#pm}'
+    elif 'Particle2' in corrName:
+        DName = 'D^{+}'
+    elif 'Particle3' in corrName:
+        DName = 'D^{#font[122]{-}}'
+
+    info.DrawLatex(0.2, 0.80, f'#LT #it{{p}}_{{T}} ({DName}) #GT = '
+                   f'{hSEPairVsPt[corrName][0].GetMean():0.2f} #pm {hSEPairVsPt[corrName][0].GetMeanError():0.2f}')
+    info.DrawLatex(0.2, 0.74, '#it{k}* < 200 MeV/#it{c}')
+cSEDistr.Modified()
+cSEDistr.Update()
+
+cSoverBvsDistr = TCanvas('cSoverBvsDistr', '', 1000, 500)
+cSoverBvsDistr.Divide(2, 1)
+axisPair = {}
+for iPad, corrName in enumerate(['Particle0_Particle2_plus_Particle1_Particle3',
+                                 'Particle0_Particle3_plus_Particle1_Particle2']):
+
+    maxSoverB = hSoverB.GetMaximum()
+    maxSEPair = hSEPairVsPt[corrName][0].GetMaximum()
+
+    hFrameSoverB = cSoverBvsDistr.cd(iPad+1).DrawFrame(0., 0., ptMax, maxSoverB,
+                                                       ';#it{p}_{T}(D^{#pm}) (GeV/#it{c});S/B')
+    hFrameSoverB.GetYaxis().SetDecimals()
+    hSoverB.Draw('same')
+    hSEPairVsPt[corrName][0].Scale(maxSoverB / maxSEPair)
+    hSEPairVsPt[corrName][0].Draw('esame')
+    kStar, avSoverB, SoverBavPt = ctypes.c_double(), ctypes.c_double(), ctypes.c_double()
+    gAverageSoverB[corrName].GetPoint(0, kStar, avSoverB)
+    gSoverBAvPt[corrName].GetPoint(0, kStar, SoverBavPt)
+    info.DrawLatex(0.2, 0.86, corrTitles[corrName])
+    info.DrawLatex(0.2, 0.80, '#it{k}* < 200 MeV/#it{c}')
+    info.DrawLatex(0.2, 0.74, f'#LT S/B #GT = '
+                   f'{avSoverB.value:0.2f} #pm {gAverageSoverB[corrName].GetErrorYlow(0):0.2f}')
+    info.DrawLatex(0.2, 0.68, 'S/B (#LT #it{p}_{T}(D^{#pm}) #GT) = '
+                   f'{SoverBavPt.value:0.2f} #pm {gSoverBAvPt[corrName].GetErrorYlow(0):0.2f}')
+    cSoverBvsDistr.cd(iPad+1).SetRightMargin(0.14)
+    cSoverBvsDistr.cd(iPad+1).SetTicky(0)
+    cSoverBvsDistr.cd(iPad+1).Modified()
+    cSoverBvsDistr.cd(iPad+1).Update()
+    axisPair[corrName] = TGaxis(gPad.GetUxmax(), gPad.GetUymin(), gPad.GetUxmax(), gPad.GetUymax(),
+                                0., maxSEPair, 510, "+L")
+    axisPair[corrName].SetLineColor(kRed+1)
+    axisPair[corrName].SetLabelColor(kRed+1)
+    axisPair[corrName].SetLabelFont(42)
+    axisPair[corrName].SetLabelSize(0.045)
+    axisPair[corrName].SetTitle('SE pairs')
+    axisPair[corrName].SetTitleOffset(1.4)
+    axisPair[corrName].SetLabelOffset(0.012)
+    axisPair[corrName].SetTitleColor(kRed+1)
+    axisPair[corrName].SetTitleFont(42)
+    axisPair[corrName].SetTitleSize(0.05)
+    axisPair[corrName].SetMaxDigits(3)
+    axisPair[corrName].Draw()
+cSoverBvsDistr.Modified()
+cSoverBvsDistr.Update()
+
+outFileName = 'SoverB_vs_kstar' + outSuffix + '.root'
+outFileName = os.path.join(outDirName, outFileName)
+outFile = TFile(outFileName, 'recreate')
+if addTDirectory:
+    outDir = TDirectoryFile(outSuffix, outSuffix)
+    outDir.Write()
+    outDir.cd()
+cSoverBvsDistr.Write()
+cSEDistr.Write()
+cSoverBvsKstar.Write()
+for corrName in gAverageSoverB:
+    gAverageSoverB[corrName].Write()
+    gSoverBAvPt[corrName].Write()
+if addTDirectory:
+    outDir.Close()
+outFile.Close()
+print('Output file saved: ', outFileName)
+
+outFileNamePDF = outFileName.replace('.root', '.pdf')
+cSEDistr.SaveAs(outFileNamePDF.replace('SoverB_vs_kstar', 'PairDistr'))
+cSoverBvsDistr.SaveAs(outFileNamePDF.replace('SoverB_vs_kstar', 'SoverB_vs_PairDistr_kstar200'))
+cSoverBvsKstar.SaveAs(outFileNamePDF)
+
+input('Press enter to exit')

--- a/femto/ProjectMassFromFemtoTask.py
+++ b/femto/ProjectMassFromFemtoTask.py
@@ -1,5 +1,5 @@
 '''
-python script for the projection of of D-meson mass spectrum from femto task
+python script for the projection of the D-meson mass spectrum from femto task
 '''
 
 import sys
@@ -18,14 +18,20 @@ parser.add_argument('outFileName', metavar='text', default='outFileName.root',
                     help='output root file name')
 parser.add_argument('--prefix', metavar='text', default='MB',
                     help='prefix for directory inside task output file')
+parser.add_argument('--suffix', metavar='text', default='0',
+                    help='suffix for directory inside task output file')
 args = parser.parse_args()
 
 with open(args.cutSetFileName, 'r') as ymlCutSetFile:
     cutSetCfg = yaml.load(ymlCutSetFile, yaml.FullLoader)
 cutVars = cutSetCfg['cutvars']
 
+listName = f'{args.prefix}_CharmFemto_DChargedQA{args.suffix}/{args.prefix}_CharmFemto_DChargedQA{args.suffix}'
+print(f'Read input file: {args.inFileName}')
+print(f'           list: {listName}')
+
 inFile = TFile.Open(args.inFileName)
-inList = inFile.Get(f'{args.prefix}_CharmFemto_DChargedQA0/{args.prefix}_CharmFemto_DChargedQA0')
+inList = inFile.Get(listName)
 hDminusMassVsPt = inList.FindObject('fHistDminusInvMassPt')
 hDplusMassVsPt = inList.FindObject('fHistDplusInvMassPt')
 hMassVsPt = hDminusMassVsPt.Clone()
@@ -59,3 +65,5 @@ for hM, hP in zip(hMass, hPt):
     hP.Write()
 hEvForNorm.Write()
 outFile.Close()
+
+print(f'Projected histograms saved in output file: {args.outFileName}')

--- a/femto/config_purity_estimate_pp13TeV_HM.yml
+++ b/femto/config_purity_estimate_pp13TeV_HM.yml
@@ -1,0 +1,13 @@
+input:
+    filename: /Users/fabrizio/cernbox/ALICE_WORK/Files/Trains/Run2/pp13TeV/AnalysisResults_Femto_Dplus_proton_HMV0_sphericity.root
+    suffix: 0
+    prefix: HM
+
+rawyields:
+    filename: /Users/fabrizio/cernbox/ALICE_WORK/AnalysisFemtopp/outputs/rawyields/RawYields_Dplus_pp13TeV_HMV0_finebins_sphericity_0dot7_1.root
+    histoname: hRawYieldsSoverB #SandBDiffNsigma/hRawYieldsSoverB_1.50sigma # 3sigma window
+
+output:
+    directory: '.'
+    suffix: masswindow_3sigma_sphericity_0dot7_1
+    addTDirectory: True # to add a TDirectory in output root file named as the suffix

--- a/femto/config_purity_estimate_pp13TeV_HM.yml
+++ b/femto/config_purity_estimate_pp13TeV_HM.yml
@@ -5,9 +5,9 @@ input:
 
 rawyields:
     filename: /Users/fabrizio/cernbox/ALICE_WORK/AnalysisFemtopp/outputs/rawyields/RawYields_Dplus_pp13TeV_HMV0_finebins_sphericity_0dot7_1.root
-    histoname: hRawYieldsSoverB #SandBDiffNsigma/hRawYieldsSoverB_1.50sigma # 3sigma window
+    histoname: SandBDiffNsigma/hRawYieldsSoverB_2.00sigma # 2sigma window
 
 output:
     directory: '.'
-    suffix: masswindow_3sigma_sphericity_0dot7_1
+    suffix: masswindow_2sigma_sphericity_0dot7_1
     addTDirectory: True # to add a TDirectory in output root file named as the suffix

--- a/systematics/fraction/ComputeTheoryDrivenFpromptMultSyst.py
+++ b/systematics/fraction/ComputeTheoryDrivenFpromptMultSyst.py
@@ -1,0 +1,111 @@
+'''
+Script for the computation of the extra systematic uncertainty
+on the theory-driven fprompt due to the multiplicity dependence
+run: python ComputeTheoryDrivenFpromptMultSyst.py fracFile.root multDepFile.root
+'''
+
+import sys
+import argparse
+import ctypes
+import numpy as np
+import uproot
+from scipy.interpolate import InterpolatedUnivariateSpline
+from ROOT import TCanvas, TFile, TGraphAsymmErrors, TLegend # pylint: disable=import-error,no-name-in-module
+from ROOT import kAzure, kRed, kGreen # pylint: disable=import-error,no-name-in-module
+sys.path.append('../..')
+from utils.StyleFormatter import SetGlobalStyle, SetObjectStyle #pylint: disable=wrong-import-position,import-error,no-name-in-module
+
+# load inputs
+parser = argparse.ArgumentParser(description='Arguments')
+parser.add_argument('fracFileName', metavar='text', default='fracFile.root',
+                    help='root file with prompt fraction (from HFPtSpectum)')
+parser.add_argument('multDepFileName', metavar='text', default='multDepFile.root',
+                    help='root file containing B/D multiplicity dependence')
+parser.add_argument('outFileName', metavar='text', default='outFile.root',
+                    help='output root file')
+parser.add_argument('--multFactor', type=float, default=1.,
+                    help='value of multiplicity wrt to MB')
+args = parser.parse_args()
+
+# set global style
+SetGlobalStyle(padleftmargin=0.18, padbottommargin=0.14, titleoffsety=1.7)
+
+inFileFrac = TFile.Open(args.fracFileName)
+gFrac = inFileFrac.Get('gFcConservative')
+if not gFrac:
+    print('ERROR: graph with prompt fraction not present in input file! Exit')
+    sys.exit()
+inFileFrac.Close()
+
+sFracRatioVsMult, multFactor = [], []
+tunes = [0, 3, 7, 8, 9]
+for tune in tunes:
+    fRatioVsMult = uproot.open(args.multDepFileName)[f'hfnonprompt_ratioMB_meson_tune{tune}']
+    multCent = [(fRatioVsMult.edges[iBin]+fRatioVsMult.edges[iBin+1])/2 for iBin in range(len(fRatioVsMult.edges)-1)]
+    sFracRatioVsMult.append(InterpolatedUnivariateSpline(multCent, fRatioVsMult.values))
+    multFactor.append(sFracRatioVsMult[-1](args.multFactor))
+
+gFracFONLLUnc, gFracMultUnc, gFracTotUnc = (TGraphAsymmErrors(0) for _ in range(3))
+SetObjectStyle(gFracFONLLUnc, color=kAzure+4, fillalpha=0.2)
+SetObjectStyle(gFracMultUnc, color=kGreen+2, fillalpha=0.2)
+SetObjectStyle(gFracTotUnc, color=kRed+1, fillalpha=0.2)
+ptMin, ptMax = -1., 1.
+for iPt in range(gFrac.GetN()-1):
+
+    promptFrac, pT = ctypes.c_double(), ctypes.c_double()
+    gFrac.GetPoint(iPt+1, pT, promptFrac)
+    FONLLUncLow = gFrac.GetErrorYlow(iPt+1)
+    FONLLUncHigh = gFrac.GetErrorYhigh(iPt+1)
+    ptUncLow = gFrac.GetErrorXlow(iPt+1)
+    ptUncHigh = gFrac.GetErrorXhigh(iPt+1)
+
+    nonPromptFrac = 1 - promptFrac.value
+    nonPromptFracLow = nonPromptFrac * min(multFactor)
+    nonPromptFracHigh = nonPromptFrac * max(multFactor)
+    uncMultDepLow = nonPromptFrac-nonPromptFracLow
+    uncMultDepHigh = nonPromptFracHigh-nonPromptFrac
+
+    # low for FD is high for prompt and viceversa
+    totUncLow = np.sqrt(FONLLUncLow**2 + uncMultDepHigh**2)
+    totUncHigh = np.sqrt(FONLLUncHigh**2 + uncMultDepLow**2)
+
+    gFracFONLLUnc.SetPoint(iPt, pT.value, promptFrac.value)
+    gFracMultUnc.SetPoint(iPt, pT.value, promptFrac.value)
+    gFracTotUnc.SetPoint(iPt, pT.value, promptFrac.value)
+    gFracFONLLUnc.SetPointError(iPt, ptUncLow, ptUncHigh, FONLLUncLow, FONLLUncHigh)
+    gFracMultUnc.SetPointError(iPt, ptUncLow, ptUncHigh, uncMultDepHigh, uncMultDepLow)
+    gFracTotUnc.SetPointError(iPt, ptUncLow, ptUncHigh, totUncLow, totUncHigh)
+
+    if iPt == 0:
+        ptMin = pT.value - ptUncLow - 1
+    if iPt == gFrac.GetN()-2:
+        ptMax = pT.value + ptUncHigh + 1
+
+leg = TLegend(0.4, 0.2, 0.7, 0.4)
+leg.SetBorderSize(0)
+leg.SetFillStyle(0)
+leg.SetTextSize(0.045)
+leg.AddEntry(gFracFONLLUnc, 'FONLL sys.', 'fp')
+leg.AddEntry(gFracMultUnc, 'Mult. dep. sys.', 'fp')
+leg.AddEntry(gFracTotUnc, 'Tot. sys.', 'fp')
+
+cFrac = TCanvas('cFrac', '', 800, 800)
+cFrac.DrawFrame(ptMin, 0.6, ptMax, 1., ';#it{p}_{T} (GeV/#it{c});#it{f}_{prompt}')
+gFracTotUnc.Draw('2')
+gFracTotUnc.Draw('p')
+gFracFONLLUnc.Draw('2')
+gFracFONLLUnc.Draw('p')
+gFracMultUnc.Draw('2')
+gFracMultUnc.Draw('p')
+leg.Draw()
+
+cFrac.SaveAs(args.outFileName.replace('.root', '.pdf'))
+
+outFile = TFile(args.outFileName, 'recreate')
+cFrac.Write()
+gFracTotUnc.Write()
+gFracFONLLUnc.Write()
+gFracMultUnc.Write()
+outFile.Close()
+
+input('Press enter to exit')

--- a/systematics/fraction/ComputeTheoryDrivenFpromptMultSyst.py
+++ b/systematics/fraction/ComputeTheoryDrivenFpromptMultSyst.py
@@ -1,7 +1,7 @@
 '''
 Script for the computation of the extra systematic uncertainty
 on the theory-driven fprompt due to the multiplicity dependence
-run: python ComputeTheoryDrivenFpromptMultSyst.py fracFile.root multDepFile.root
+run: python ComputeTheoryDrivenFpromptMultSyst.py fracFile.root multDepFile.root outFile.root [--multFactor MULTFACTOR]
 '''
 
 import sys


### PR DESCRIPTION
- Add script to evaluate multiplicity-dependent FD systematic uncertainty on theory-driven fprompt
- Add script to evaluate S/B vs k* for femtoscopy analyses
- Minor developments in yield extraction scripts
  - Add S, B, S/B, and significance histos for alternative mass windows
  - Automatically add more canvanses in case of more than 20 pt bins (pads)

@fcatalan92 @stefanopolitano please have a look especially if the improvements in the raw-yield extraction scripts are fine with you, thanks!