### PR TITLE
Fixes in fitting macros

### DIFF
--- a/GetRawYieldsDplusDs.C
+++ b/GetRawYieldsDplusDs.C
@@ -101,11 +101,19 @@ int GetRawYieldsDplusDs(int cent, bool isMC, TString infilename, TString cfgfile
         {
             BkgFunc[iPt] = 6;
             degPol[iPt] = 3;
+            if (PtMin.size() > 1) {
+                cerr << "Pol3 and Pol4 fits work only with one bin at the moment! Exit" << endl;
+                return -1;
+            }
         }
         else if(bkgfunc[iPt] == "kPol4")
         {
             BkgFunc[iPt] = 6;
             degPol[iPt] = 4;
+            if (PtMin.size() > 1) {
+                cerr << "Pol3 and Pol4 fits work only with one bin at the moment! Exit" << endl;
+                return -1;
+            }
         }
         else
         {
@@ -563,10 +571,6 @@ int GetRawYieldsDplusDs(int cent, bool isMC, TString infilename, TString cfgfile
                     cResiduals[iCanv]->cd();
                 massFitter->DrawHistoMinusFit(gPad);
             }
-
-            // plotting issue not understood when used high degree polynomials for at least one pT bin
-            auto bkgFunc = massFitter->GetBackgroundFullRangeFunc();
-            delete bkgFunc;
         }
         cMass[iCanv]->Modified();
         cMass[iCanv]->Update();

--- a/GetRawYieldsDplusDs.C
+++ b/GetRawYieldsDplusDs.C
@@ -101,8 +101,8 @@ int GetRawYieldsDplusDs(int cent, bool isMC, TString infilename, TString cfgfile
         {
             BkgFunc[iPt] = 6;
             degPol[iPt] = 3;
-            if (PtMin.size() > 1) {
-                cerr << "Pol3 and Pol4 fits work only with one bin at the moment! Exit" << endl;
+            if (PtMin.size() > 1 && InclSecPeak[iPt] == 1) {
+                cerr << "Pol3 and Pol4 fits work only with one bin if you have the secondary peak! Exit!" << endl;
                 return -1;
             }
         }
@@ -110,8 +110,8 @@ int GetRawYieldsDplusDs(int cent, bool isMC, TString infilename, TString cfgfile
         {
             BkgFunc[iPt] = 6;
             degPol[iPt] = 4;
-            if (PtMin.size() > 1) {
-                cerr << "Pol3 and Pol4 fits work only with one bin at the moment! Exit" << endl;
+            if (PtMin.size() > 1 && InclSecPeak[iPt] == 1) {
+                cerr << "Pol3 and Pol4 fits work only with one bin if you have the secondary peak! Exit!" << endl;
                 return -1;
             }
         }

--- a/GetRawYieldsDplusDs.py
+++ b/GetRawYieldsDplusDs.py
@@ -61,9 +61,15 @@ for iPt, (bkg, sgn) in enumerate(zip(fitConfig[cent]['BkgFunc'], fitConfig[cent]
     elif bkg == 'kPol3':
         BkgFunc.append(6)
         degPol[-1] = 3
+        if len(ptMins) > 1:
+            print('ERROR: Pol3 and Pol4 fits work only with one bin at the moment! Exit')
+            sys.exit()
     elif bkg == 'kPol4':
         BkgFunc.append(6)
         degPol[-1] = 4
+        if len(ptMins) > 1:
+            print('ERROR: Pol3 and Pol4 fits work only with one bin at the moment! Exit')
+            sys.exit()
     else:
         print('ERROR: only kExpo, kLin, kPol2, kPol3, and kPol4 background functions supported! Exit')
         sys.exit()
@@ -505,7 +511,6 @@ for iPt, (hM, ptMin, ptMax, reb, sgn, bkg, secPeak, massMin, massMax) in enumera
 
     cMass[iCanv].Modified()
     cMass[iCanv].Update()
-
     cResiduals[iCanv].Modified()
     cResiduals[iCanv].Update()
 

--- a/GetRawYieldsDplusDs.py
+++ b/GetRawYieldsDplusDs.py
@@ -61,14 +61,14 @@ for iPt, (bkg, sgn) in enumerate(zip(fitConfig[cent]['BkgFunc'], fitConfig[cent]
     elif bkg == 'kPol3':
         BkgFunc.append(6)
         degPol[-1] = 3
-        if len(ptMins) > 1:
-            print('ERROR: Pol3 and Pol4 fits work only with one bin at the moment! Exit')
+        if len(ptMins) > 1 and inclSecPeak[iPt] == 1:
+            print('ERROR: Pol3 and Pol4 fits work only with one bin if you have the secondary peak! Exit!')
             sys.exit()
     elif bkg == 'kPol4':
         BkgFunc.append(6)
         degPol[-1] = 4
-        if len(ptMins) > 1:
-            print('ERROR: Pol3 and Pol4 fits work only with one bin at the moment! Exit')
+        if len(ptMins) > 1 and inclSecPeak[iPt] == 1:
+            print('ERROR: Pol3 and Pol4 fits work only with one bin if you have the secondary peak! Exit!')
             sys.exit()
     else:
         print('ERROR: only kExpo, kLin, kPol2, kPol3, and kPol4 background functions supported! Exit')

--- a/GetRawYieldsDplusDs.py
+++ b/GetRawYieldsDplusDs.py
@@ -554,7 +554,7 @@ if not args.isMC:
 outFile.Close()
 
 outFileNamePDF = args.outFileName.replace('.root', '.pdf')
-outFileNameResPDF = outFileNamePDF.replace('.root', '_Residuals.pdf')
+outFileNameResPDF = outFileNamePDF.replace('.pdf', '_Residuals.pdf')
 for iCanv, (cM, cR) in enumerate(zip(cMass, cResiduals)):
     if iCanv == 0 and nCanvases > 1:
         cM.SaveAs(f'{outFileNamePDF}[')


### PR DESCRIPTION
@fgrosa I checked and the fits do not work properly using pol3 or pol4 and more than one pT bin.
The problem should be related to the fact that we do not destroy the `InvMassFitter` in the loop over the pT bins (if we do we loose the plots at the moment) and probably something should be fixed directly in https://github.com/fcatalan92/AliPhysics/blob/e378944adc3e4d103714c0e703ad6276dca9d67e/PWGHF/vertexingHF/AliHFInvMassFitter.cxx#L242 for the case of higher-order polynomial (everything is fine for the other cases)