### PR TITLE
Add flag to pass weights for the different B hadron species

### DIFF
--- a/ProjectDplusDsSparse.py
+++ b/ProjectDplusDsSparse.py
@@ -202,7 +202,7 @@ for iPt, (ptMin, ptMax) in enumerate(zip(cutVars['Pt']['min'], cutVars['Pt']['ma
                                 weight = args.Bspeciesweights[iBspecie-1]
                                 if sPtWeightsB(ptCentB) > 0:
                                     weight *= sPtWeightsB(ptCentB)
-                                content = hPtBvsBspecievsPtD.GetBinContent(iPtD, iBspecie, iPtB) * weight
+                                content = origContent * weight
                                 error = 0
                                 if origContent > 0:
                                     error = origError / origContent * content

--- a/ProjectDplusDsSparse.py
+++ b/ProjectDplusDsSparse.py
@@ -236,7 +236,7 @@ for iPt, (ptMin, ptMax) in enumerate(zip(cutVars['Pt']['min'], cutVars['Pt']['ma
                             origContent = hBspecievsPtD.GetBinContent(iPtD, iBspecie)
                             origError = hBspecievsPtD.GetBinError(iPtD, iBspecie)
                             weight = args.Bspeciesweights[iBspecie-1]
-                            content = hBspecievsPtD.GetBinContent(iPtD, iBspecie) * weight
+                            content = origContent * weight
                             error = 0
                             if origContent > 0:
                                 error = origError / origContent * content

--- a/ProjectDplusDsSparse.py
+++ b/ProjectDplusDsSparse.py
@@ -325,7 +325,7 @@ for iPt, (ptMin, ptMax) in enumerate(zip(cutVars['Pt']['min'], cutVars['Pt']['ma
                     origContent = hBspecievsPtGenD.GetBinContent(iPtD, iBspecie)
                     origError = hBspecievsPtGenD.GetBinError(iPtD, iBspecie)
                     weight = args.Bspeciesweights[iBspecie-1]
-                    content = hBspecievsPtGenD.GetBinContent(iPtD, iBspecie) * weight
+                    content = origContent * weight
                     error = 0
                     if origContent > 0:
                         error = origError / origContent * content

--- a/ProjectDplusDsSparse.py
+++ b/ProjectDplusDsSparse.py
@@ -291,7 +291,7 @@ for iPt, (ptMin, ptMax) in enumerate(zip(cutVars['Pt']['min'], cutVars['Pt']['ma
                         weight = args.Bspeciesweights[iBspecie-1]
                         if sPtWeightsB(ptCentB) > 0:
                             weight *= sPtWeightsB(ptCentB)
-                        content = hPtBvsBspecievsPtGenD.GetBinContent(iPtD, iBspecie, iPtB) * weight
+                        content = origContent * weight
                         error = 0
                         if origContent > 0:
                             error = origError / origContent * content


### PR DESCRIPTION
- Add new argument to the `argparse` to provide different weights for the different b-hadron species: `--Bspeciesweights`
  -  it requires 5 `floats`, each of them corresponding to the weight to be applied to each b-hadron species (i.e. `--Bspeciesweights 1. 1. 2. 1. 1.` if you want to weight twice the Bs) 
- @stefanopolitano it is tested to work but not the effect on the results, which I would leave it to you. It would be also useful to check that it gives the same result as `--Bspecie` when only one weight is different from 0. Once verified this, we can remove the `--Bspecie` argument which would be a duplication of `--Bspeciesweights`