### PR TITLE
Fixing problems in two scripts

### DIFF
--- a/ComputeEffAccWeightedAvg.py
+++ b/ComputeEffAccWeightedAvg.py
@@ -77,12 +77,13 @@ BR = [3.5 * 1e-02, 1.96 * 0.667 * 1e-02, 1.08 * 1e-02, 2.2 * 0.225 * 1e-02]
 nPtBins = hEffPrompt[0].GetNbinsX()
 for iPt in range(nPtBins):
     effC, effB, uncEffC, uncEffB, sumOfW = (0. for _ in range(5))
-    for histo, br, in zip(hEffPrompt, BR):
-        effC += histo.GetBinContent(iPt+1) * br
-        effB += histo.GetBinContent(iPt+1) * br
-        uncEffC += histo.GetBinError(iPt+1)**2 * br**2
-        uncEffB += histo.GetBinError(iPt+1)**2 * br**2
+    for histoC, br, in zip(hEffPrompt, BR):
+        effC += histoC.GetBinContent(iPt+1) * br
+        uncEffC += histoC.GetBinError(iPt+1)**2 * br**2
         sumOfW += br
+    for histoB, br, in zip(hEffFD, BR):
+        effB += histoB.GetBinContent(iPt+1) * br
+        uncEffB += histoB.GetBinError(iPt+1)**2 * br**2
     hEffCw.SetBinContent(iPt+1, (effC/sumOfW))
     hEffCw.SetBinError(iPt+1, np.sqrt(uncEffC)/sumOfW)
     hEffBw.SetBinContent(iPt+1, (effB/sumOfW))

--- a/RunFullAnalysis.sh
+++ b/RunFullAnalysis.sh
@@ -266,8 +266,10 @@ if $DoEfficiency; then
   do
     if [ ${Particle} == "LctopKpi" ]; then
       for Channel in "${LctopKpi_reso_channel[@]}";
+      do
         echo $(tput setaf 4) Compute efficiency from ${OutDirEfficiency}/Distr_${Particle}${Channel}_MC${CutSets[$iCutSet]}.root $(tput sgr0)
         python3 ComputeEfficiencyDplusDs.py ${cfgFileFit} ${Cent} ${OutDirEfficiency}/Distr_${Particle}${Channel}_MC${CutSets[$iCutSet]}.root ${OutDirEfficiency}/Efficiency_${Particle}${Channel}${CutSets[$iCutSet]}.root --batch
+      done
     elif [ ${Particle} != "LctopKpi" ]; then
       echo $(tput setaf 4) Compute efficiency from ${OutDirEfficiency}/Distr_${Particle}_MC${CutSets[$iCutSet]}.root $(tput sgr0)
       python3 ComputeEfficiencyDplusDs.py ${cfgFileFit} ${Cent} ${OutDirEfficiency}/Distr_${Particle}_MC${CutSets[$iCutSet]}.root ${OutDirEfficiency}/Efficiency_${Particle}${CutSets[$iCutSet]}.root --batch
@@ -281,8 +283,10 @@ if $DoAccEff; then
   do
     if [ ${Particle} == "LctopKpi" ]; then
     for Channel in "${LctopKpi_reso_channel[@]}";
+    do
       echo $(tput setaf 4) Compute efficiency times acceptance ${Particle} ${Channel} $(tput sgr0)
       python3 CombineAccTimesEff.py ${OutDirEfficiency}/Efficiency_${Particle}${Channel}${CutSets[$iCutSet]}.root ${accFileName} ${OutDirEfficiency}/Eff_times_Acc_${Particle}${Channel}${CutSets[$iCutSet]}.root --batch
+    done
     elif [ ${Particle} != "LctopKpi" ]; then
       echo $(tput setaf 4) Compute efficiency times acceptance $(tput sgr0)
       python3 CombineAccTimesEff.py ${OutDirEfficiency}/Efficiency_${Particle}${CutSets[$iCutSet]}.root ${accFileName} ${OutDirEfficiency}/Eff_times_Acc_${Particle}${CutSets[$iCutSet]}.root --batch


### PR DESCRIPTION
I open this PR to fix two main problems:
- in `RunFullAnalysis.sh` there was a syntax error at line 269 and 286 due to the missing syntax `do...done` for the for-loop
- in `ComputeEffAccWeightedAvg.py` there was an error in the loop where the weighted average is computed. Indeed, in the previous review of the code many changes were done and it accidentally occured that the prompt histograms were used as input for both prompt and FD weighted averages. Now this is fixed.

@fgrosa could you have a look and review it?

Thanks and regards,
Stefano