### PR TITLE
Code for D meson flow in Run 3

### DIFF
--- a/run3/flow/README_FLOW.md
+++ b/run3/flow/README_FLOW.md
@@ -1,0 +1,23 @@
+# Flow Analysis in Run 3
+
+Code for the measurement of D meson flow starting from the outputs of the [taskFlowCharmHadrons.cxx](https://github.com/AliceO2Group/O2Physics/blob/master/PWGHF/D2H/Tasks/taskFlowCharmHadrons.cxx) task using rectangular or ML selections performed with the [hipe4ml](https://github.com/hipe4ml/hipe4ml) package.
+
+## Prerequisites
+The code in this repository requires having installed: 
+- [python3](https://www.python.org)(>=3.6)
+- [AliPhysics](https://github.com/alisw/AliPhysics) (until simultaneous fit is ported to flarefly/O2Physics)
+- [hipe4ml](https://github.com/hipe4ml/hipe4ml)(>=0.0.10 or installed from dev branch)
+- [pyaml](https://pypi.org/project/pyaml)
+- [alive_progress](https://github.com/rsalmei/alive-progress)
+
+## Analysis flow
+The analysis flow is organized as follows:
+.                
+└── flow                        # The folder containing flow analysis material
+    ├── compute_reso.py         # Compute SP/EP resolution term
+    ├── project_thnsparse.py    # Projcect ThnSparse as a function of pT/centrality from AnalysisResults.root
+    ├── get_vn_vs_mass.py       # Simultanoues fit to the project inv. mass and EP/SP
+
+The full analysis chain can be run with run_full_flow_analysis.py. 
+
+The python scripts necessitate of a configuration file like config_flow.yml

--- a/run3/flow/README_FLOW.md
+++ b/run3/flow/README_FLOW.md
@@ -4,7 +4,7 @@ Code for the measurement of D meson flow starting from the outputs of the [taskF
 
 ## Analysis steps
 The analysis is organized as follows:
-- `compute_reso.py: compute SP/EP resolution term
+- `compute_reso.py`: compute SP/EP resolution term
 - `project_thnsparse.py`: projcect ThnSparse as a function of pT/centrality from AnalysisResults.root
 - `get_vn_vs_mass.py`: Simultaneous fit to the projected inv. mass and EP/SP
 

--- a/run3/flow/README_FLOW.md
+++ b/run3/flow/README_FLOW.md
@@ -2,22 +2,12 @@
 
 Code for the measurement of D meson flow starting from the outputs of the [taskFlowCharmHadrons.cxx](https://github.com/AliceO2Group/O2Physics/blob/master/PWGHF/D2H/Tasks/taskFlowCharmHadrons.cxx) task using rectangular or ML selections performed with the [hipe4ml](https://github.com/hipe4ml/hipe4ml) package.
 
-## Prerequisites
-The code in this repository requires having installed: 
-- [python3](https://www.python.org)(>=3.6)
-- [AliPhysics](https://github.com/alisw/AliPhysics) (until simultaneous fit is ported to flarefly/O2Physics)
-- [hipe4ml](https://github.com/hipe4ml/hipe4ml)(>=0.0.10 or installed from dev branch)
-- [pyaml](https://pypi.org/project/pyaml)
-- [alive_progress](https://github.com/rsalmei/alive-progress)
+## Analysis steps
+The analysis is organized as follows:
+- `compute_reso.py: compute SP/EP resolution term
+- `project_thnsparse.py`: projcect ThnSparse as a function of pT/centrality from AnalysisResults.root
+- `get_vn_vs_mass.py`: Simultaneous fit to the projected inv. mass and EP/SP
 
-## Analysis flow
-The analysis flow is organized as follows:
-.                
-└── flow                        # The folder containing flow analysis material
-    ├── compute_reso.py         # Compute SP/EP resolution term
-    ├── project_thnsparse.py    # Projcect ThnSparse as a function of pT/centrality from AnalysisResults.root
-    ├── get_vn_vs_mass.py       # Simultanoues fit to the project inv. mass and EP/SP
+The full analysis chain can be run with ``run_full_flow_analysis.py``.
 
-The full analysis chain can be run with run_full_flow_analysis.py. 
-
-The python scripts necessitate of a configuration file like config_flow.yml
+The python scripts necessitate a configuration file like ``config_flow.yml``.

--- a/run3/flow/compute_reso.py
+++ b/run3/flow/compute_reso.py
@@ -1,0 +1,123 @@
+import sys
+import argparse
+import ROOT
+from flow_analysis_utils import get_resolution
+sys.path.append('../../')
+from utils.StyleFormatter import SetObjectStyle, SetGlobalStyle
+SetGlobalStyle(padleftmargin=0.15, padlebottommargin=0.25,
+               padrightmargin=0.15, titleoffsety=1.1, maxdigits=3, titlesizex=0.03,
+               labelsizey=0.04, setoptstat=0, setopttitle=0)
+
+ROOT.gROOT.SetBatch(False)
+
+# TODO: move this to the StyleFormatter
+def SetFrameStyle(hFrame, xtitle, ytitle, ytitleoffset, ytitlesize, ylabelsize,
+                  ylabeloffset, xticklength, yticklength, xtitlesize, xlabelsize,
+                  xtitleoffset, xlabeloffset, ydivisions, xmoreloglabels, ycentertitle, ymaxdigits):
+    hFrame.GetXaxis().SetTitle(xtitle)
+    hFrame.GetYaxis().SetTitle(ytitle)
+    hFrame.GetYaxis().SetTitleOffset(ytitleoffset)
+    hFrame.GetYaxis().SetTitleSize(ytitlesize)
+    hFrame.GetYaxis().SetLabelSize(ylabelsize)
+    hFrame.GetYaxis().SetLabelOffset(ylabeloffset)
+    hFrame.GetXaxis().SetTickLength(xticklength)
+    hFrame.GetYaxis().SetTickLength(yticklength)
+    hFrame.GetXaxis().SetTitleSize(xtitlesize)
+    hFrame.GetXaxis().SetLabelSize(xlabelsize)
+    hFrame.GetXaxis().SetTitleOffset(xtitleoffset)
+    hFrame.GetXaxis().SetLabelOffset(xlabeloffset)
+    hFrame.GetYaxis().SetNdivisions(ydivisions)
+    hFrame.GetXaxis().SetMoreLogLabels(xmoreloglabels)
+    hFrame.GetYaxis().CenterTitle(ycentertitle)
+    hFrame.GetYaxis().SetMaxDigits(ymaxdigits)
+
+# TODO: move this to the StyleFormatter
+def LatLabel(label, x, y, size):
+    latex = ROOT.TLatex()
+    latex.SetNDC()
+    latex.SetTextSize(size)
+    latex.DrawLatex(x, y, label)
+
+def compute_reso(an_res_file, doEP, outputdir, suffix):
+
+    detA = ['FT0c', 'FT0c', 'FT0c', 'FT0c']
+    detB = ['FT0a', 'FT0a', 'FT0a', 'TPCpos']
+    detC = ['FV0a', 'TPCpos', 'TPCneg', 'TPCneg']
+
+    outfile_name = f'{outputdir}resoSP{suffix}.root' if not doEP else f'{outputdir}resoEP{suffix}.root'
+    outfile = ROOT.TFile(outfile_name, 'RECREATE')
+    for i, (det_a, det_b, det_c) in enumerate(zip(detA, detB, detC)):
+        hist_reso, histos_det,\
+        histo_means = get_resolution(an_res_file,
+                                     [det_a, det_b, det_c],
+                                     0,
+                                     100,
+                                     doEP)
+        hist_reso.SetDirectory(0)
+        hist_reso.SetName(f'hist_reso_{det_a}_{det_b}_{det_c}')
+        hist_reso.GetXaxis().SetTitle('centrality (%)')
+        hist_reso.GetYaxis().SetTitle(f'#it{{R}}_{{2}}{{SP}} ({det_a}, {det_b}, {det_c})') if not doEP else hist_reso.GetYaxis().SetTitle(f'#it{{R}}_{{2}}{{EP}} ({det_a}, {det_b}, {det_c})')
+
+        for i, (hist_det, hist_mean) in enumerate(zip(histos_det, histo_means)):
+            outfile.cd()
+            outfile.mkdir(f'{det_a}_{det_b}_{det_c}')
+            outfile.cd(f'{det_a}_{det_b}_{det_c}')
+            SetObjectStyle(hist_mean, color=ROOT.kRed, markerstyle=ROOT.kFullCircle,
+                   markersize=1, fillstyle=0, linewidth=2)
+            canv_name = hist_det.GetName().replace('h', 'canv')
+            canvas = ROOT.TCanvas(canv_name, canv_name, 800, 800)
+            canvas.SetLogz()
+            hFrame = canvas.cd().DrawFrame(0, -2, 100, 2)
+            
+            SetFrameStyle(hFrame,
+                          xtitle='Cent. FT0c (%)',
+                          ytitle='cos(2(#Psi^{A}-#Psi^{B}))' if doEP else 'Q^{A} Q^{B}',
+                          ytitleoffset=1.15,
+                          ytitlesize=0.05,
+                          ylabelsize=0.04,
+                          ylabeloffset=0.01,
+                          xticklength=0.04,
+                          yticklength=0.03,
+                          xtitlesize=0.05,
+                          xlabelsize=0.04,
+                          xtitleoffset=0.9,
+                          xlabeloffset=0.020,
+                          ydivisions=406,
+                          xmoreloglabels=True,
+                          ycentertitle=True,
+                          ymaxdigits=5,)
+            hist_det.Draw('same colz')
+            hist_mean.Draw('same pl')
+            if i == 0:
+                LatLabel(f'A: {det_a}, B: {det_b}', 0.2, 0.85, 0.05)
+            elif i == 1:
+                LatLabel(f'A: {det_a}, B: {det_c}', 0.2, 0.85, 0.05)
+            elif i == 2:
+                LatLabel(f'A: {det_b}, B: {det_c}', 0.2, 0.85, 0.05)
+            canvas.Write()
+            hist_mean.Write()
+            hist_det.Write()
+        hist_reso.SetDirectory(outfile)
+        hist_reso.Write()
+        outfile.cd('..')
+
+    input(f'Press enter to continue')
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Arguments")
+    parser.add_argument("an_res_file", metavar="text",
+                        default="an_res.root", help="input ROOT file with anres")
+    parser.add_argument("--doEP",  action="store_true", default=False,
+                        help="do EP resolution")
+    parser.add_argument("--outputdir", "-o", metavar="text",
+                        default=".", help="output directory")
+    parser.add_argument("--suffix", "-s", metavar="text",
+                        default="", help="suffix for output files")
+    args = parser.parse_args()
+
+    compute_reso(
+        an_res_file=args.an_res_file,
+        doEP=args.doEP,
+        outputdir=args.outputdir,
+        suffix=args.suffix
+        )

--- a/run3/flow/config_flow.yml
+++ b/run3/flow/config_flow.yml
@@ -11,26 +11,39 @@ axes: {mass: 0,
 harmonic: 2 # 2: v2, 3: v3, etc.
 
 # pt bins
-ptmins: [4] #, 5, 6, 7] #, 8, 12, 16, 24, 36]
-ptmaxs: [6] #, 6, 7, 8] #, 10, 16, 24, 36, 50]
+ptmins: [1, 2, 3, 4, 5, 6] 
+ptmaxs: [2, 3, 4, 5, 6, 7]
 
 # inv_mass_bins (one for each pt bin)
 inv_mass_bins: [[1.74, 1.78, 1.82, 1.84, 1.85, 1.86, 1.87, 1.88, 1.89, 1.90, 1.92, 1.96, 2.00],
+                [1.74, 1.78, 1.82, 1.84, 1.85, 1.86, 1.87, 1.88, 1.89, 1.90, 1.92, 1.96, 2.00],
+                [1.74, 1.78, 1.82, 1.84, 1.85, 1.86, 1.87, 1.88, 1.89, 1.90, 1.92, 1.96, 2.00],
+                [1.74, 1.78, 1.82, 1.84, 1.85, 1.86, 1.87, 1.88, 1.89, 1.90, 1.92, 1.96, 2.00],
+                [1.74, 1.78, 1.82, 1.84, 1.85, 1.86, 1.87, 1.88, 1.89, 1.90, 1.92, 1.96, 2.00],
+                [1.74, 1.78, 1.82, 1.84, 1.85, 1.86, 1.87, 1.88, 1.89, 1.90, 1.92, 1.96, 2.00],
+                [1.74, 1.78, 1.82, 1.84, 1.85, 1.86, 1.87, 1.88, 1.89, 1.90, 1.92, 1.96, 2.00],
+                [1.74, 1.78, 1.82, 1.84, 1.85, 1.86, 1.87, 1.88, 1.89, 1.90, 1.92, 1.96, 2.00],
                 [1.74, 1.78, 1.82, 1.84, 1.85, 1.86, 1.87, 1.88, 1.89, 1.90, 1.92, 1.96, 2.00],]
 
+
+
 # bdt cut
-bdt_cut: {
-       bkg: { 
-              min: [0.002, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
-              max: [0.05, 0.4, 0.4, 0.4, 0.4, 0.4, 0.4],
-              step: [0.002, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2]
-                },
-       sig: { 
-              min: [0.5, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2],
-              max: [1.0, 0.8, 0.8, 0.8, 0.8, 0.8, 0.8],
-              step: [0.1, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2]
-                }     
-}
+apply_btd_cuts: false # apply bdt cuts
+bkg_ml_cuts: [0.08, 0.08, 0.08, 0.08, 0.08, 0.08] # max probability for bkg, one for each pt bin
+sig_ml_cuts: [0.6, 0.6, 0.6, 0.6, 0.6, 0.6]       # min probability for sig, one for each pt bin
+cut_variation:
+       bdt_cut: {
+              bkg: { 
+                     min: [0.002, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                     max: [0.05, 0.4, 0.4, 0.4, 0.4, 0.4, 0.4],
+                     step: [0.002, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2]
+                       },
+              sig: { 
+                     min: [0.5, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2],
+                     max: [1.0, 0.8, 0.8, 0.8, 0.8, 0.8, 0.8],
+                     step: [0.1, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2]
+                       }     
+       }
 
 
 # ep/sp subevents
@@ -56,7 +69,7 @@ FixSigmaToFirstPeak: 0
 UseLikelihood: 1
 BkgFunc: [ 'kExpo', 'kExpo', 'kExpo', 'kExpo', 'kExpo', 'kExpo', 'kExpo', 'kExpo', 'kExpo', 'kExpo', 'kExpo', 'kExpo', 'kExpo', 'kExpo', 'kExpo', 'kExpo', 'kExpo', 'kExpo', 'kExpo', 'kExpo', 'kExpo' ]
 SgnFunc: [ 'kGaus', 'kGaus', 'kGaus', 'kGaus', 'kGaus', 'kGaus', 'kGaus', 'kGaus', 'kGaus', 'kGaus', 'kGaus', 'kGaus', 'kGaus', 'kGaus', 'kGaus', 'kGaus', 'kGaus', 'kGaus', 'kGaus', 'kGaus', 'kGaus' ]
-BkgFuncVn: ['kLin', kLin', 'kPol3', 'kLin', 'kLin', 'kLin', 'kLin', 'kLin', 'kLin', 'kLin', 'kLin', 'kLin', 'kLin', 'kLin', 'kLin', 'kLin', 'kLin', 'kLin', 'kLin', 'kLin', 'kLin' ]
+BkgFuncVn: ['kLin', kLin', 'kPol2', 'kLin', 'kLin', 'kLin', 'kLin', 'kLin', 'kLin', 'kLin', 'kLin', 'kLin', 'kLin', 'kLin', 'kLin', 'kLin', 'kLin', 'kLin', 'kLin', 'kLin', 'kLin' ]
 FixSigmaRatio: 0 # used only if SgnFunc = k2GausSigmaRatioPar
 SigmaRatioFile: ""
 BoundMean: 0 # 0: Do not set limits on mean range, 1: the mean is set to be between MassMin[i] and MassMax[i]

--- a/run3/flow/config_flow.yml
+++ b/run3/flow/config_flow.yml
@@ -1,0 +1,58 @@
+# global info (do not change)
+axes: {mass: 0,
+       pt: 1,
+       cent: 2,
+       sp: 5,
+       deltaphi: 4,
+       phi: 3,
+       bdt_bkg: 6,
+       bdt_sig: 7}
+
+# bins
+ptmins: [4] #, 5, 6, 7] #, 8, 12, 16, 24, 36]
+ptmaxs: [6] #, 6, 7, 8] #, 10, 16, 24, 36, 50]
+
+centrality_bins: [30, 50]
+
+# bdt cut
+bdt_cut: {
+       bkg: { 
+              min: [0.002, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+              max: [0.05, 0.4, 0.4, 0.4, 0.4, 0.4, 0.4],
+              step: [0.002, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2]
+                },
+       sig: { 
+              min: [0.5, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2],
+              max: [1.0, 0.8, 0.8, 0.8, 0.8, 0.8, 0.8],
+              step: [0.1, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2]
+                }     
+}
+
+
+# ep/sp subevents
+detA: 'FT0c'
+detB: 'FT0a'
+detC: 'TPCpos'
+
+# fit options
+Dmeson: 'Dplus'
+FixSigma: 0
+SigmaFile: ''
+SigmaMultFactor: 1.
+FixMean: 0
+MeanFile: ''
+MassMin: [ 1.74, 1.74, 1.74, 1.74, 1.74, 1.74, 1.74, 1.74, 1.74, 1.74, 1.74, 1.74, 1.74, 1.74, 1.74, 1.74, 1.70, 1.70, 1.70, 1.70, 1.70 ] 
+MassMax: [ 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00 ]
+Rebin: [20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20]
+InclSecPeak: [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ]
+SigmaSecPeak: []
+SigmaFileSecPeak: ''
+SigmaMultFactorSecPeak: 1.
+FixSigmaToFirstPeak: 0
+UseLikelihood: 1
+BkgFunc: [ 'kExpo', 'kExpo', 'kExpo', 'kExpo', 'kExpo', 'kExpo', 'kExpo', 'kExpo', 'kExpo', 'kExpo', 'kExpo', 'kExpo', 'kExpo', 'kExpo', 'kExpo', 'kExpo', 'kExpo', 'kExpo', 'kExpo', 'kExpo', 'kExpo' ]
+SgnFunc: [ 'kGaus', 'kGaus', 'kGaus', 'kGaus', 'kGaus', 'kGaus', 'kGaus', 'kGaus', 'kGaus', 'kGaus', 'kGaus', 'kGaus', 'kGaus', 'kGaus', 'kGaus', 'kGaus', 'kGaus', 'kGaus', 'kGaus', 'kGaus', 'kGaus' ]
+BkgFuncVn: ['kLin', kLin', 'kPol3', 'kLin', 'kLin', 'kLin', 'kLin', 'kLin', 'kLin', 'kLin', 'kLin', 'kLin', 'kLin', 'kLin', 'kLin', 'kLin', 'kLin', 'kLin', 'kLin', 'kLin', 'kLin' ]
+FixSigmaRatio: 0 # used only if SgnFunc = k2GausSigmaRatioPar
+SigmaRatioFile: ""
+BoundMean: 0 # 0: Do not set limits on mean range, 1: the mean is set to be between MassMin[i] and MassMax[i]

--- a/run3/flow/config_flow.yml
+++ b/run3/flow/config_flow.yml
@@ -69,7 +69,7 @@ FixSigmaToFirstPeak: 0
 UseLikelihood: 1
 BkgFunc: [ 'kExpo', 'kExpo', 'kExpo', 'kExpo', 'kExpo', 'kExpo', 'kExpo', 'kExpo', 'kExpo', 'kExpo', 'kExpo', 'kExpo', 'kExpo', 'kExpo', 'kExpo', 'kExpo', 'kExpo', 'kExpo', 'kExpo', 'kExpo', 'kExpo' ]
 SgnFunc: [ 'kGaus', 'kGaus', 'kGaus', 'kGaus', 'kGaus', 'kGaus', 'kGaus', 'kGaus', 'kGaus', 'kGaus', 'kGaus', 'kGaus', 'kGaus', 'kGaus', 'kGaus', 'kGaus', 'kGaus', 'kGaus', 'kGaus', 'kGaus', 'kGaus' ]
-BkgFuncVn: ['kLin', kLin', 'kPol2', 'kLin', 'kLin', 'kLin', 'kLin', 'kLin', 'kLin', 'kLin', 'kLin', 'kLin', 'kLin', 'kLin', 'kLin', 'kLin', 'kLin', 'kLin', 'kLin', 'kLin', 'kLin' ]
+BkgFuncVn: ['kLin', 'kLin', 'kPol2', 'kLin', 'kLin', 'kLin', 'kLin', 'kLin', 'kLin', 'kLin', 'kLin', 'kLin', 'kLin', 'kLin', 'kLin', 'kLin', 'kLin', 'kLin', 'kLin', 'kLin', 'kLin' ]
 FixSigmaRatio: 0 # used only if SgnFunc = k2GausSigmaRatioPar
 SigmaRatioFile: ""
 BoundMean: 0 # 0: Do not set limits on mean range, 1: the mean is set to be between MassMin[i] and MassMax[i]

--- a/run3/flow/config_flow.yml
+++ b/run3/flow/config_flow.yml
@@ -8,11 +8,15 @@ axes: {mass: 0,
        bdt_bkg: 6,
        bdt_sig: 7}
 
-# bins
+harmonic: 2 # 2: v2, 3: v3, etc.
+
+# pt bins
 ptmins: [4] #, 5, 6, 7] #, 8, 12, 16, 24, 36]
 ptmaxs: [6] #, 6, 7, 8] #, 10, 16, 24, 36, 50]
 
-centrality_bins: [30, 50]
+# inv_mass_bins (one for each pt bin)
+inv_mass_bins: [[1.74, 1.78, 1.82, 1.84, 1.85, 1.86, 1.87, 1.88, 1.89, 1.90, 1.92, 1.96, 2.00],
+                [1.74, 1.78, 1.82, 1.84, 1.85, 1.86, 1.87, 1.88, 1.89, 1.90, 1.92, 1.96, 2.00],]
 
 # bdt cut
 bdt_cut: {

--- a/run3/flow/cut_variation.py
+++ b/run3/flow/cut_variation.py
@@ -1,0 +1,110 @@
+import ROOT
+import yaml
+import argparse
+import numpy as np
+import sys
+from alive_progress import alive_bar
+sys.path.append('..')
+from flow_analysis_utils import get_vn_versus_mass, get_centrality_bins, compute_r2
+
+def cut_var(config, an_res_file, centrality, outputdir, suffix, do_ep):
+    with open(config, 'r') as ymlCfgFile:
+        config = yaml.load(ymlCfgFile, yaml.FullLoader)
+    pt_mins = config['ptmins']
+    pt_maxs = config['ptmaxs']
+    _, cent_bins = get_centrality_bins(centrality)
+    det_A = config['detA']
+    det_B = config['detB']
+    det_C = config['detC']
+    axis_cent = config['axes']['cent']
+    axis_pt = config['axes']['pt']
+    axis_mass = config['axes']['mass']
+    axis_sp = config['axes']['sp']
+    axis_deltaphi = config['axes']['deltaphi']
+    inv_mass_bins = config['inv_mass_bins']
+    axis_bdt_bkg = config['axes']['bdt_bkg']
+    axis_bdt_sig = config['axes']['bdt_sig']
+    bkg_cut_mins = config['cut_variation']['bdt_cut']['bkg']['min']
+    bkg_cut_maxs = config['cut_variation']['bdt_cut']['bkg']['max']
+    bkg_cut_steps = config['cut_variation']['bdt_cut']['bkg']['step']
+    sig_cut_mins = config['cut_variation']['bdt_cut']['sig']['min']
+    sig_cut_maxs = config['cut_variation']['bdt_cut']['sig']['max']
+    sig_cut_steps = config['cut_variation']['bdt_cut']['sig']['step']
+
+    infile = ROOT.TFile(an_res_file, 'READ')
+    thnsparse = infile.Get('hf-task-flow-charm-hadrons_id10397/hSparseFlowCharm')
+
+    outfile = ROOT.TFile(f'{outputdir}/cut_var{suffix}.root', 'RECREATE')
+    hist_reso = ROOT.TH1F('hist_reso', 'hist_reso', len(cent_bins) - 1, cent_bins[0], cent_bins[-1])
+    cent_min = cent_bins[0]
+    cent_max = cent_bins[1]
+    thnsparse_selcent = thnsparse.Clone(f'thnsparse_selcent{cent_min}_{cent_max}')
+    thnsparse_selcent.GetAxis(axis_cent).SetRangeUser(cent_min, cent_max)
+    reso = compute_r2(infile, cent_min, cent_max, det_A, det_B, det_C, do_ep)
+    hist_reso.SetBinContent(hist_reso.FindBin(cent_min), reso)
+
+    for ipt, (pt_min, pt_max) in enumerate(zip(pt_mins, pt_maxs)):
+        print(f'Processing pt bin {pt_min} - {pt_max}')
+        inv_mass_bin = inv_mass_bins[ipt]
+        outfile.mkdir(f'cent_bins{cent_min}_{cent_max}/pt_bins{pt_min}_{pt_max}')
+        thnsparse_selcent.GetAxis(axis_pt).SetRangeUser(pt_min, pt_max)
+        bkg_cut_pt = [cut for cut in np.arange(bkg_cut_mins[ipt], bkg_cut_maxs[ipt], bkg_cut_steps[ipt])]
+        sig_cut_pt = [cut for cut in np.arange(sig_cut_mins[ipt], sig_cut_maxs[ipt], sig_cut_steps[ipt])]
+        outfile.cd(f'cent_bins{cent_min}_{cent_max}/pt_bins{pt_min}_{pt_max}')
+        with alive_bar(len(bkg_cut_pt) * len(sig_cut_pt), title='Processing BDT cuts') as bar:
+            for _, (bkg_cut) in enumerate(bkg_cut_pt):
+                for _, (sgn_cut) in enumerate(sig_cut_pt):
+                    hist_out_label = f'cent{cent_min}_{cent_max}_pt{pt_min}_{pt_max}_bkg{bkg_cut}_sig{sgn_cut}'
+                    thnsparse_selcent.GetAxis(axis_bdt_bkg).SetRangeUser(0, bkg_cut)
+                    thnsparse_selcent.GetAxis(axis_bdt_sig).SetRangeUser(sgn_cut, 1.05)
+                    hist_mass = thnsparse_selcent.Projection(axis_mass)
+                    hist_mass.SetName(f'hist_mass_{hist_out_label}')
+                    hist_mass.Write()
+                    if do_ep:
+                        hist_vn_ep = get_vn_versus_mass(thnsparse_selcent, inv_mass_bin,
+                                                        axis_mass, axis_deltaphi, False)
+                        hist_vn_ep.SetName(f'hist_vn_ep_{hist_out_label}')
+                        hist_vn_ep.SetDirectory(0)
+                        if reso > 0:
+                            hist_vn_ep.Scale(1./reso)
+                        hist_vn_ep.Write()
+                    else:
+                        hist_vn_sp = get_vn_versus_mass(thnsparse_selcent, inv_mass_bin, axis_mass, axis_sp)
+                        hist_vn_sp.SetDirectory(0)
+                        hist_vn_sp.SetName(f'hist_vn_sp_{hist_out_label}')
+                        if reso > 0:
+                            hist_vn_sp.Scale(1./reso)
+                        hist_vn_sp.Write()
+                bar()
+        outfile.cd('..')
+    outfile.cd()
+    hist_reso.Write()
+    outfile.Close()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Arguments")
+    parser = argparse.ArgumentParser(description="Arguments")
+    parser.add_argument("config", metavar="text",
+                        default="config.yaml", help="configuration file")
+    parser.add_argument("an_res_file", metavar="text",
+                        default="an_res.root", help="input ROOT file with anres")
+    parser.add_argument("--centrality", "-c", metavar="text",
+                        default="k3050", help="centrality class")
+    parser.add_argument("--outputdir", "-o", metavar="text",
+                        default=".", help="output directory")
+    parser.add_argument("--suffix", "-s", metavar="text",
+                        default="", help="suffix for output files")
+    parser.add_argument("--doEP",  action="store_true", default=False,
+                        help="do EP resolution")
+    args = parser.parse_args()
+
+    cut_var(
+        config=args.config,
+        an_res_file=args.an_res_file,
+        centrality=args.centrality,
+        outputdir=args.outputdir,
+        suffix=args.suffix,
+        do_ep=args.doEP
+    )
+

--- a/run3/flow/flow_analysis_utils.py
+++ b/run3/flow/flow_analysis_utils.py
@@ -1,0 +1,151 @@
+'''
+Analysis utilities for flow analysis
+'''
+import ROOT
+import sys
+import numpy as np
+
+def get_vn_versus_mass(thnSparse, inv_mass_bins, mass_axis, vn_axis, debug=False):
+    '''
+    Project vn versus mass
+
+    Input:
+        - thnSparse:
+            THnSparse, input THnSparse obeject (already projected in centrality and pt)
+        - inv_mass_bins:
+            list of floats, bin edges for the mass axis
+        - mass_axis:
+            int, axis number for mass
+        - vn_axis:
+            int, axis number for vn
+        - debug:
+            bool, if True, create a debug file with the projections (default: False)
+
+    Output:
+        - hist_mass_proj:
+            TH1D, histogram with vn as a function of mass
+    '''
+    hist_vn_proj = thnSparse.Projection(vn_axis, mass_axis)
+    hist_mass_proj = thnSparse.Projection(mass_axis)
+    hist_mass_proj.Reset()
+    invmass_bins = np.array(inv_mass_bins)
+    hist_mass_proj = ROOT.TH1D('hist_mass_proj', 'hist_mass_proj', len(invmass_bins)-1, invmass_bins)
+    
+    if debug:
+        outfile = ROOT.TFile('debug.root', 'RECREATE')
+    
+    for i in range(hist_mass_proj.GetNbinsX()):
+        bin_low = hist_vn_proj.GetXaxis().FindBin(invmass_bins[i])
+        bin_high = hist_vn_proj.GetXaxis().FindBin(invmass_bins[i+1])
+        profile = hist_vn_proj.ProfileY(f'profile_{bin_low}_{bin_high}', bin_low, bin_high)
+        mean_sp = profile.GetMean()
+        mean_sp_err = profile.GetMeanError()
+        hist_mass_proj.SetBinContent(i+1, mean_sp)
+        hist_mass_proj.SetBinError(i+1, mean_sp_err)
+    
+    if debug:
+        hist_vn_proj.Write()
+        hist_mass_proj.Write()
+        outfile.Close()
+    
+    return hist_mass_proj
+
+def get_resolution(resolution_file_name, dets, centMin, centMax, doEP=False):
+    '''
+    Compute resolution for SP or EP method
+
+    Input:
+        - resolution_file_name: 
+            str, path to the resolution file
+        - dets: 
+            list of strings, subsystems to compute the resolution
+            if 2 subsystems are given, the resolution is computed as the product of the two
+            if 3 subsystems are given, the resolution is computed as the product of the first two divided by the third
+        - centMin:
+            int, minimum centrality bin
+        - centMax:
+            int, maximum centrality bin
+        - doEP:
+            bool, if True, compute EP resolution
+            if False, compute SP resolution (default)
+
+    Output:
+        - histo_reso:
+            TH1D, histogram with the resolution value as a function of centrality
+        - histo_dets:
+            list of TH1D, list of projections used to compute the resolution
+        - histo_means:
+            list of TH1D, list of histograms with the mean value of the projections as a function of centrality
+    '''
+    infile = ROOT.TFile(resolution_file_name, 'READ')
+    histo_projs, histo_dets, histo_means = [], [], []
+    detA = dets[0]
+    detB = dets[1]
+    if len(dets) == 3:
+        detC = dets[2]
+    dets = [f'{detA}{detB}', f'{detA}{detC}', f'{detB}{detC}'] if len(dets) == 3 else [f'{detA}{detB}']
+    
+    # set path and prefix
+    if doEP:
+        path = 'hf-task-flow-charm-hadrons/epReso/'
+        prefix = 'EpReso'
+    else:
+        path = 'hf-task-flow-charm-hadrons/spReso/'
+        prefix = 'SpReso'
+   
+    # collect the qvecs and the prepare histo for mean and resolution
+    for det in dets:
+        histo_dets.append(infile.Get(f'{path}h{prefix}{det}'))
+        histo_dets[-1].SetDirectory(0)
+        histo_dets[-1].SetName(f'h{prefix}{det}')
+        histo_means.append(histo_dets[-1].ProjectionX(f'proj_{histo_dets[-1].GetName()}_mean'))
+        histo_means[-1].SetDirectory(0)
+        histo_means[-1].Reset()
+        histo_projs.append([])
+
+        # collect projections
+        for cent in range(centMin, centMax):
+            bin_cent_low = histo_dets[-1].GetXaxis().FindBin(cent) # common binning
+            bin_cent_high = histo_dets[-1].GetXaxis().FindBin(cent)
+            histo_projs[-1].append(histo_dets[-1].ProjectionY(f'proj_{histo_dets[-1].GetName()}_{cent}_{cent}', bin_cent_low, bin_cent_high))
+            histo_projs[-1][-1].SetDirectory(0)
+
+        # Appllying absolute value to the projections
+        for ihist, _ in enumerate(histo_projs[-1]): histo_means[-1].SetBinContent(ihist+1, histo_projs[-1][ihist].GetMean())
+    infile.Close()
+
+    histo_reso = ROOT.TH1F('', '', 100, 0, 100)
+    histo_reso.SetDirectory(0)
+    for icent in range(centMin, centMax):
+        histo_reso.SetBinContent(icent+1, compute_resolution([histo_means[i].GetBinContent(icent+1) for i in range(len(dets))]))
+
+    return histo_reso, histo_dets, histo_means
+
+
+def compute_resolution(subMean):
+    '''
+    Compute resolution for SP or EP method
+
+    Input:
+        - subMean:
+            list of floats, list of mean values of the projections
+
+    Output:
+        - resolution:
+            float, resolution value
+    '''
+    if len(subMean) == 1:
+        resolution =  subMean[0]
+        if resolution <= 0:
+            return 0
+        else:
+            return np.sqrt(resolution)
+    elif len(subMean) == 3:
+        resolution = (subMean[2] * subMean[1]) / subMean[0] if subMean[0] != 0 else 0
+        if resolution <= 0:
+            return 0
+        else:
+            return np.sqrt(resolution)
+    else:
+        print('ERROR: dets must be a list of 2 or 3 subsystems')
+        sys.exit(1)

--- a/run3/flow/flow_analysis_utils.py
+++ b/run3/flow/flow_analysis_utils.py
@@ -149,3 +149,35 @@ def compute_resolution(subMean):
     else:
         print('ERROR: dets must be a list of 2 or 3 subsystems')
         sys.exit(1)
+
+def get_centrality_bins(centrality):
+    '''
+    Get centrality bins
+
+    Input:
+        - centrality:
+            str, centrality class (e.g. 'k3050')
+
+    Output:
+        - cent_bins:
+            list of floats, centrality bins
+        - cent_label:
+            str, centrality label
+    '''
+    if centrality == 'k010':
+        return '0_10', [0, 10]
+    if centrality == 'k2030':
+        return '20_30', [20, 30]
+    elif centrality == 'k3040':
+        return '30_40', [30, 40]
+    elif centrality == 'k3050':
+        return '30_50', [30, 50]
+    elif centrality == 'k4050':
+        return '40_50', [40, 50]
+    elif centrality == 'k4060':
+        return '40_60', [40, 60]
+    elif centrality == 'k6080':
+        return '60_80', [60, 80]
+    else:
+        print(f"ERROR: cent class \'{centrality}\' is not supported! Exit")
+    sys.exit()

--- a/run3/flow/get_vn_vs_mass.py
+++ b/run3/flow/get_vn_vs_mass.py
@@ -1,0 +1,856 @@
+'''
+Script for fitting D+, D0 and Ds+ invariant-mass spectra
+run: python get_vn_vs_mass.py fitConfigFileName.yml centClass inputFileName.root outFileName.root
+            [--refFileName][--isMC][--batch]
+'''
+
+import sys
+import argparse
+import ctypes
+import numpy as np
+import yaml
+from ROOT import TFile, TCanvas, TH1D, TH1F, TF1, TDatabasePDG, TDirectoryFile, AliHFInvMassFitter, AliVertexingHFUtils, AliHFVnVsMassFitter, TGraphAsymmErrors # pylint: disable=import-error,no-name-in-module
+from ROOT import gROOT, gPad, kBlack, kRed, kFullCircle, kFullSquare # pylint: disable=import-error,no-name-in-module
+sys.path.append('../../')
+from utils.StyleFormatter import SetGlobalStyle, SetObjectStyle, DivideCanvas
+from utils.FitUtils import SingleGaus, DoubleGaus, DoublePeakSingleGaus, DoublePeakDoubleGaus
+
+parser = argparse.ArgumentParser(description='Arguments')
+parser.add_argument('fitConfigFileName', metavar='text', default='config_Ds_Fit.yml')
+parser.add_argument('centClass', metavar='text', default='')
+parser.add_argument('inFileName', metavar='text', default='')
+parser.add_argument("--outputdir", "-o", metavar="text",
+                    default=".", help="output directory")
+parser.add_argument("--suffix", "-s", metavar="text",
+                    default="", help="suffix for output files")
+parser.add_argument('--refFileName', metavar='text', default='')
+parser.add_argument('--isOutOfPlane', action='store_true', default=False)
+parser.add_argument('--isInPlane', action='store_true', default=False)
+parser.add_argument('--doEP', action='store_true', default=False)
+parser.add_argument('--isMC', action='store_true', default=False)
+parser.add_argument('--batch', help='suppress video output', action='store_true')
+args = parser.parse_args()
+
+cent = ''
+if args.centClass == 'k010':
+    cent = '0_10'
+if args.centClass == 'k2030':
+    cent = '20_30'
+elif args.centClass == 'k3040':
+    cent = '30_40'
+elif args.centClass == 'k3050':
+    cent = '30_50'
+elif args.centClass == 'k4050':
+    cent = '40_50'
+elif args.centClass == 'k4060':
+    cent = '40_60'
+elif args.centClass == 'k6080':
+    cent = '60_80'
+elif args.centClass == 'kpp5TeVPrompt':
+    cent = 'pp5TeVPrompt'
+elif args.centClass == 'kpp13TeVFD':
+    cent = 'pp13TeVFD'
+elif args.centClass == 'kpp13TeVPrompt':
+    cent = 'pp13TeVPrompt'
+else:
+    print(f"ERROR: cent class \'{args.centClass}\' is not supported! Exit")
+    sys.exit()
+
+
+with open(args.fitConfigFileName, 'r', encoding='utf8') as ymlfitConfigFile:
+    fitConfig = yaml.load(ymlfitConfigFile, yaml.FullLoader)
+
+gROOT.SetBatch(args.batch)
+SetGlobalStyle(padleftmargin=0.14, padbottommargin=0.12, padtopmargin=0.12, opttitle=1)
+
+ptMins = fitConfig['ptmins']
+ptMaxs = fitConfig['ptmaxs']
+fixSigma = fitConfig['FixSigma']
+fixMean = fitConfig['FixMean']
+if 'EnableRef' not in fitConfig:
+    enableRef = False
+else:
+    enableRef = fitConfig['EnableRef']
+if not isinstance(fixSigma, list):
+    fixSigma = [fixSigma for _ in ptMins]
+if not isinstance(fixMean, list):
+    fixMean = [fixMean for _ in ptMins]
+ptLims = list(ptMins)
+nPtBins = len(ptMins)
+ptLims.append(ptMaxs[-1])
+
+particleName = fitConfig['Dmeson']
+inclSecPeak = fitConfig['InclSecPeak']
+
+SgnFuncStr = fitConfig['SgnFunc']
+if not isinstance(SgnFuncStr, list):
+    SgnFuncStr = [SgnFuncStr] * nPtBins
+
+BkgFuncStr = fitConfig['BkgFunc']
+if not isinstance(BkgFuncStr, list):
+    BkgFuncStr = [BkgFuncStr] * nPtBins
+
+BkgFuncVnStr = fitConfig['BkgFuncVn']
+if not isinstance(BkgFuncVnStr, list):
+    BkgFuncVn = [BkgFuncVnStr] * nPtBins
+
+SgnFunc, BkgFunc, BkgFuncVn, degPol = [], [], [], []
+for iPt, (bkgStr, sgnStr, bkgVnStr) in enumerate(zip(BkgFuncStr, SgnFuncStr, BkgFuncVnStr)):
+    degPol.append(-1)
+    if bkgStr == 'kExpo':
+        BkgFunc.append(AliHFInvMassFitter.kExpo)
+    elif bkgStr == 'kLin':
+        BkgFunc.append(AliHFInvMassFitter.kLin)
+    elif bkgStr == 'kPol2':
+        BkgFunc.append(AliHFInvMassFitter.kPol2)
+    elif bkgStr == 'kPol3':
+        BkgFunc.append(6)
+        degPol[-1] = 3
+        if len(ptMins) > 1 and inclSecPeak[iPt] == 1:
+            print('ERROR: Pol3 and Pol4 fits work only with one bin if you have the secondary peak! Exit!')
+            sys.exit()
+    elif bkgStr == 'kPol4':
+        BkgFunc.append(6)
+        degPol[-1] = 4
+        if len(ptMins) > 1 and inclSecPeak[iPt] == 1:
+            print('ERROR: Pol3 and Pol4 fits work only with one bin if you have the secondary peak! Exit!')
+            sys.exit()
+    elif bkgStr == 'kPow':
+        BkgFunc.append(AliHFInvMassFitter.kPow)
+    elif bkgStr == 'kPowEx':
+        BkgFunc.append(AliHFInvMassFitter.kPowEx)
+    else:
+        print('ERROR: only kExpo, kLin, kPol2, kPol3, kPol4, kPow, and kPowEx background functions supported! Exit')
+        sys.exit()
+
+    if bkgVnStr == 'kExpo':
+        BkgFuncVn.append(AliHFInvMassFitter.kExpo)
+    elif bkgVnStr == 'kLin':
+        BkgFuncVn.append(AliHFInvMassFitter.kLin)
+    elif bkgVnStr == 'kPol2':
+        BkgFuncVn.append(AliHFInvMassFitter.kPol2)
+    #else:
+    #    print('ERROR: only kExpo, kLin, and kPol2 background functions supported for vn! Exit')
+    #    sys.exit()
+
+    if sgnStr == 'kGaus':
+        SgnFunc.append(AliHFInvMassFitter.kGaus)
+    elif sgnStr == 'k2Gaus':
+        SgnFunc.append(AliHFInvMassFitter.k2Gaus)
+    elif sgnStr == 'k2GausSigmaRatioPar':
+        SgnFunc.append(AliHFInvMassFitter.k2GausSigmaRatioPar)
+    else:
+        print('ERROR: only kGaus, k2Gaus and k2GausSigmaRatioPar signal functions supported! Exit!')
+        sys.exit()
+
+if particleName == 'Dplus':
+    massAxisTit = '#it{M}(K#pi#pi) (GeV/#it{c}^{2})'
+elif particleName == 'Ds':
+    massAxisTit = '#it{M}(KK#pi) (GeV/#it{c}^{2})'
+elif particleName == 'LctopKpi':
+    massAxisTit = '#it{M}(pK#pi) (GeV/#it{c}^{2})'
+elif particleName == 'LctopK0s':
+    massAxisTit = '#it{M}(pK^{0}_{s}) (GeV/#it{c}^{2})'
+elif particleName == 'Dstar':
+    massAxisTit = '#it{M}(K#pi#pi) - #it{M}(K#pi) (GeV/#it{c}^{2})'
+elif particleName == 'D0':
+    massAxisTit = '#it{M}(K#pi) (GeV/#it{c}^{2})'
+else:
+    print(f'ERROR: the particle "{particleName}" is not supported! Choose between Dplus, Ds, Dstar, and Lc. Exit!')
+    sys.exit()
+
+# load inv-mass histos
+infile = TFile.Open(args.inFileName)
+if not infile or not infile.IsOpen():
+    print(f'ERROR: file "{args.inFileName}" cannot be opened! Exit!')
+    sys.exit()
+if enableRef:
+    infileref = TFile.Open(args.refFileName)
+    if not (infileref and infileref.IsOpen()):
+        print(f'ERROR: file "{args.refFileName}" cannot be opened! Exit!')
+        sys.exit()
+
+hRel, hSig, hMassForRel, hMassForSig  = [], [], [], []
+hMass, hMassForFit, hVn, hVnForFit = [], [], [], []
+inclSecPeak = [inclSecPeak] * len(ptMins) if not isinstance(inclSecPeak, list) else inclSecPeak
+for iPt, (ptMin, ptMax, secPeak) in enumerate(zip(ptMins, ptMaxs, inclSecPeak)):
+    if not args.isMC:
+        print(f'loading: cent_bins{cent}/pt_bins{ptMin}_{ptMax}/hist_mass_cent{cent}_pt{ptMin}_{ptMax}')
+        hMass.append(infile.Get(f'cent_bins{cent}/pt_bins{ptMin}_{ptMax}/hist_mass_cent{cent}_pt{ptMin}_{ptMax}'))
+        hMass[iPt].SetDirectory(0)
+        if args.doEP:
+            print(f'loading: cent_bins{cent}/pt_bins{ptMin}_{ptMax}/hist_vn_ep_pt{ptMin}_{ptMax}')
+            hVn.append(infile.Get(f'cent_bins{cent}/pt_bins{ptMin}_{ptMax}/hist_vn_ep_pt{ptMin}_{ptMax}'))
+        else:
+            print(f'loading: cent_bins{cent}/pt_bins{ptMin}_{ptMax}/hist_vn_sp_pt{ptMin}_{ptMax}')
+            hVn.append(infile.Get(f'cent_bins{cent}/pt_bins{ptMin}_{ptMax}/hist_vn_sp_pt{ptMin}_{ptMax}'))
+        hVn[iPt].SetDirectory(0)
+        if enableRef:
+            hRel.append(infileref.Get(f'hVarReflMass_{ptMin*10:.0f}_{ptMax*10:.0f}'))
+            hSig.append(infileref.Get(f'hFDMass_{ptMin*10:.0f}_{ptMax*10:.0f}'))
+            hSig[iPt].Add(infileref.Get(f'hPromptMass_{ptMin*10:.0f}_{ptMax*10:.0f}'))
+            hRel[iPt].SetDirectory(0)
+            hSig[iPt].SetDirectory(0)
+            hRel[iPt].Sumw2()
+            hSig[iPt].Sumw2()
+    else:
+        hMass.append(infile.Get(f'hPromptMass_{ptMin*10:.0f}_{ptMax*10:.0f}'))
+        hMass[iPt].Add(infile.Get(f'hFDMass_{ptMin*10:.0f}_{ptMax*10:.0f}'))
+        if secPeak:
+            hMass[iPt].Add(infile.Get(f'hPromptSecPeakMass_{ptMin*10:.0f}_{ptMax*10:.0f}'))
+            hMass[iPt].Add(infile.Get(f'hFDSecPeakMass_{ptMin*10:.0f}_{ptMax*10:.0f}'))
+        hMass[iPt].SetDirectory(0)
+    hMass[iPt].Sumw2()
+    SetObjectStyle(hMass[iPt], color=kBlack, markerstyle=kFullCircle)
+    SetObjectStyle(hVn[iPt], color=kBlack, markerstyle=kFullCircle)
+
+#hEv = infile.Get('hEvForNorm')
+hEv = TH1D('', '', 1, 0, 1)
+hEv.SetDirectory(0)
+hEv.Sumw2()
+SetObjectStyle(hEv, color=kBlack, markerstyle=kFullCircle)
+infile.Close()
+
+hSigmaToFix = None
+if sum(fixSigma) > 0:
+    infileSigma = TFile.Open(fitConfig['SigmaFile'])
+    if not infileSigma:
+        print(f'ERROR: file "{infileSigma}" cannot be opened! Exit!')
+        sys.exit()
+    hSigmaToFix = infileSigma.Get('hRawYieldsSigma')
+    hSigmaToFix.SetDirectory(0)
+    if hSigmaToFix.GetNbinsX() != nPtBins:
+        print('WARNING: Different number of bins for this analysis and histo for fix sigma')
+    infileSigma.Close()
+
+if fitConfig['FixSigmaRatio']:
+    # load sigma of first gaussian
+    infileSigma = TFile.Open(fitConfig['SigmaRatioFile'])
+    if not infileSigma:
+        print(f'ERROR: file "{infileSigma}" cannot be opened! Exit!')
+        sys.exit()
+    hSigmaToFix = infileSigma.Get('hRawYieldsSigma')
+    hSigmaToFix.SetDirectory(0)
+    if hSigmaToFix.GetNbinsX() != nPtBins:
+        print('WARNING: Different number of bins for this analysis and histo for fix sigma')
+    infileSigma.Close()
+    # load sigma of second gaussian
+    infileSigma2 = TFile.Open(fitConfig['SigmaRatioFile'])
+    if not infileSigma2:
+        print(f'ERROR: file "{infileSigma2}" cannot be opened! Exit!')
+        sys.exit()
+    hSigmaToFix2 = infileSigma2.Get('hRawYieldsSigma2')
+    hSigmaToFix2.SetDirectory(0)
+    if hSigmaToFix2.GetNbinsX() != nPtBins:
+        print('WARNING: Different number of bins for this analysis and histo for fix sigma')
+    infileSigma2.Close()
+
+hMeanToFix = None
+if sum(fixMean) > 0:
+    infileMean = TFile.Open(fitConfig['MeanFile'])
+    if not infileMean:
+        print(f'ERROR: file "{infileMean}" cannot be opened! Exit!')
+        sys.exit()
+    hMeanToFix = infileMean.Get('hRawYieldsMean')
+    hMeanToFix.SetDirectory(0)
+    if hMeanToFix.GetNbinsX() != nPtBins:
+        print('WARNING: Different number of bins for this analysis and histo for fix mean')
+    infileMean.Close()
+
+hSigmaFirstPeakMC = None
+hSigmaToFixSecPeak = None
+infileSigmaSecPeak = None
+if fitConfig['SigmaFileSecPeak']:
+    infileSigmaSecPeak = TFile.Open(fitConfig['SigmaFileSecPeak'])
+if fitConfig['FixSigmaToFirstPeak'] and not infileSigmaSecPeak:
+    print(f'ERROR: file "{fitConfig["SigmaFileSecPeak"]}" cannot be opened! Exit!')
+    sys.exit()
+if infileSigmaSecPeak:
+    hSigmaFirstPeakMC = infileSigmaSecPeak.Get("hRawYieldsSigma")
+    hSigmaToFixSecPeak = infileSigmaSecPeak.Get("hRawYieldsSigmaSecondPeak")
+    hSigmaFirstPeakMC.SetDirectory(0)
+    hSigmaToFixSecPeak.SetDirectory(0)
+    if hSigmaFirstPeakMC.GetNbinsX() != nPtBins or hSigmaToFixSecPeak.GetNbinsX() != nPtBins:
+        print('WARNING: Different number of bins for this analysis and histoss for fix mean')
+    infileSigmaSecPeak.Close()
+
+ptBinsArr = np.asarray(ptLims, 'd')
+ptTit = '#it{p}_{T} (GeV/#it{c})'
+
+hRawYields = TH1D('hRawYields', f';{ptTit};raw yield', nPtBins, ptBinsArr)
+hRawYieldsSigma = TH1D('hRawYieldsSigma', f';{ptTit};width (GeV/#it{{c}}^{{2}})', nPtBins, ptBinsArr)
+hRawYieldsSigma2 = TH1D('hRawYieldsSigma2', f';{ptTit};width (GeV/#it{{c}}^{{2}})', nPtBins, ptBinsArr)
+hRawYieldsMean = TH1D('hRawYieldsMean', f';{ptTit};mean (GeV/#it{{c}}^{{2}})', nPtBins, ptBinsArr)
+hRawYieldsFracGaus2 = TH1D('hRawYieldsFracGaus2', f';{ptTit};second-gaussian fraction', nPtBins, ptBinsArr)
+hRawYieldsSignificance = TH1D('hRawYieldsSignificance', f';{ptTit};significance (3#sigma)', nPtBins, ptBinsArr)
+hRawYieldsSoverB = TH1D('hRawYieldsSoverB', f';{ptTit};S/B (3#sigma)', nPtBins, ptBinsArr)
+hRawYieldsSignal = TH1D('hRawYieldsSignal', f';{ptTit};Signal (3#sigma)', nPtBins, ptBinsArr)
+hRawYieldsBkg = TH1D('hRawYieldsBkg', f';{ptTit};Background (3#sigma)', nPtBins, ptBinsArr)
+hRawYieldsChiSquare = TH1D('hRawYieldsChiSquare', f';{ptTit};#chi^{{2}}/#it{{ndf}}', nPtBins, ptBinsArr)
+hRawYieldsSecPeak = TH1D('hRawYieldsSecondPeak', f';{ptTit};raw yield second peak', nPtBins, ptBinsArr)
+hRawYieldsMeanSecPeak = TH1D('hRawYieldsMeanSecondPeak', f';{ptTit};mean second peak (GeV/#it{{c}}^{{2}})',
+                             nPtBins, ptBinsArr)
+hRawYieldsSigmaSecPeak = TH1D('hRawYieldsSigmaSecondPeak', f';{ptTit};width second peak (GeV/#it{{c}}^{{2}})',
+                              nPtBins, ptBinsArr)
+hRawYieldsSignificanceSecPeak = TH1D('hRawYieldsSignificanceSecondPeak',
+                                     f';{ptTit};signficance second peak (3#sigma)', nPtBins, ptBinsArr)
+hRawYieldsSigmaRatioSecondFirstPeak = TH1D('hRawYieldsSigmaRatioSecondFirstPeak',
+                                           f';{ptTit};width second peak / width first peak', nPtBins, ptBinsArr)
+hRawYieldsSoverBSecPeak = TH1D('hRawYieldsSoverBSecondPeak', f';{ptTit};S/B second peak (3#sigma)',
+                               nPtBins, ptBinsArr)
+hRawYieldsSignalSecPeak = TH1D('hRawYieldsSignalSecondPeak', f';{ptTit};Signal second peak (3#sigma)',
+                               nPtBins, ptBinsArr)
+hRawYieldsBkgSecPeak = TH1D('hRawYieldsBkgSecondPeak', f';{ptTit};Background second peak (3#sigma)',
+                            nPtBins, ptBinsArr)
+hRawYieldsTrue = TH1D('hRawYieldsTrue', f';{ptTit};true signal', nPtBins, ptBinsArr)
+hRawYieldsSecPeakTrue = TH1D('hRawYieldsSecondPeakTrue', f';{ptTit};true signal second peak',
+                             nPtBins, ptBinsArr)
+hRelDiffRawYieldsFitTrue = TH1D('hRelDiffRawYieldsFitTrue', f';{ptTit}; (Y_{{fit}} - Y_{{true}}) / Y_{{true}}',
+                                nPtBins, ptBinsArr)
+hRelDiffRawYieldsSecPeakFitTrue = TH1D('hRelDiffRawYieldsSecondPeakFitTrue',
+                                       f';{ptTit};(Y_{{fit}} - Y_{{true}}) / Y_{{true}} second peak',
+                                       nPtBins, ptBinsArr)
+
+hSigmaSimFit = TH1D('hSigmaSimFit', f';{ptTit};#sigma', nPtBins, ptBinsArr)
+hMeanSimFit = TH1D('hMeanSimFit', f';{ptTit};mean', nPtBins, ptBinsArr)
+hRedChi2SimFit = TH1D('hRedChi2SimFit', f';{ptTit};#chi^{{2}}/#it{{ndf}}', nPtBins, ptBinsArr)
+hProbSimFit = TH1D('hProbSimFit', f';{ptTit};prob', nPtBins, ptBinsArr)
+hRedChi2SBVnPrefit = TH1D('hRedChi2SBVnPrefit', f';{ptTit};#chi^{{2}}/#it{{ndf}}', nPtBins, ptBinsArr)
+hProbSBVnPrefit = TH1D('hProbSBVnPrefit', f';{ptTit};prob', nPtBins, ptBinsArr)
+gvnSimFit = TGraphAsymmErrors(1)
+
+
+SetObjectStyle(hRawYields, color=kBlack, markerstyle=kFullCircle)
+SetObjectStyle(hRawYieldsSigma, color=kBlack, markerstyle=kFullCircle)
+SetObjectStyle(hRawYieldsSigma2, color=kBlack, markerstyle=kFullCircle)
+SetObjectStyle(hRawYieldsMean, color=kBlack, markerstyle=kFullCircle)
+SetObjectStyle(hRawYieldsFracGaus2, color=kBlack, markerstyle=kFullCircle)
+SetObjectStyle(hRawYieldsSignificance, color=kBlack, markerstyle=kFullCircle)
+SetObjectStyle(hRawYieldsSoverB, color=kBlack, markerstyle=kFullCircle)
+SetObjectStyle(hRawYieldsSignal, color=kBlack, markerstyle=kFullCircle)
+SetObjectStyle(hRawYieldsBkg, color=kBlack, markerstyle=kFullCircle)
+SetObjectStyle(hRawYieldsChiSquare, color=kBlack, markerstyle=kFullCircle)
+SetObjectStyle(hRawYieldsSecPeak, color=kRed, markerstyle=kFullSquare)
+SetObjectStyle(hRawYieldsMeanSecPeak, color=kRed, markerstyle=kFullSquare)
+SetObjectStyle(hRawYieldsSigmaSecPeak, color=kRed, markerstyle=kFullSquare)
+SetObjectStyle(hRawYieldsSignificanceSecPeak, color=kRed, markerstyle=kFullSquare)
+SetObjectStyle(hRawYieldsSigmaRatioSecondFirstPeak, color=kRed, markerstyle=kFullSquare)
+SetObjectStyle(hRawYieldsSoverBSecPeak, color=kRed, markerstyle=kFullSquare)
+SetObjectStyle(hRawYieldsSignalSecPeak, color=kRed, markerstyle=kFullSquare)
+SetObjectStyle(hRawYieldsBkgSecPeak, color=kRed, markerstyle=kFullSquare)
+SetObjectStyle(hRawYieldsTrue, color=kRed, markerstyle=kFullSquare)
+SetObjectStyle(hRawYieldsSecPeakTrue, color=kRed, markerstyle=kFullSquare)
+SetObjectStyle(hRelDiffRawYieldsFitTrue, color=kRed, markerstyle=kFullSquare)
+SetObjectStyle(hRelDiffRawYieldsSecPeakFitTrue, color=kRed, markerstyle=kFullSquare)
+
+# additional S, B, S/B, and significance histos for different Nsigma values (filled only in case of data)
+nSigma4SandB = [1.5, 1.75, 2., 2.25, 2.5, 2.75]
+hRawYieldsSignalDiffSigma, hRawYieldsBkgDiffSigma, hRawYieldsSoverBDiffSigma, \
+    hRawYieldsSignifDiffSigma = ([] for _ in range(4))
+
+for iS, sigma in enumerate(nSigma4SandB):
+    hRawYieldsSignalDiffSigma.append(TH1D(f'hRawYieldsSignal_{sigma:0.2f}sigma',
+                                          f';{ptTit};Signal ({sigma:0.2f}#sigma)', nPtBins, ptBinsArr))
+    hRawYieldsBkgDiffSigma.append(TH1D(f'hRawYieldsBkg_{sigma:0.2f}sigma',
+                                       f';{ptTit};Background ({sigma:0.2f}#sigma)', nPtBins, ptBinsArr))
+    hRawYieldsSoverBDiffSigma.append(TH1D(f'hRawYieldsSoverB_{sigma:0.2f}sigma',
+                                          f';{ptTit};S/B ({sigma:0.2f}#sigma)', nPtBins, ptBinsArr))
+    hRawYieldsSignifDiffSigma.append(TH1D(f'hRawYieldsSignif_{sigma:0.2f}sigma',
+                                          f';{ptTit};significance ({sigma:0.2f}#sigma)', nPtBins, ptBinsArr))
+    SetObjectStyle(hRawYieldsSignalDiffSigma[iS], color=kBlack, markerstyle=kFullCircle)
+    SetObjectStyle(hRawYieldsBkgDiffSigma[iS], color=kBlack, markerstyle=kFullCircle)
+    SetObjectStyle(hRawYieldsSoverBDiffSigma[iS], color=kBlack, markerstyle=kFullCircle)
+    SetObjectStyle(hRawYieldsSignifDiffSigma[iS], color=kBlack, markerstyle=kFullCircle)
+
+# fit histos
+massDplus = TDatabasePDG.Instance().GetParticle(411).Mass()
+massDs = TDatabasePDG.Instance().GetParticle(431).Mass()
+massLc = TDatabasePDG.Instance().GetParticle(4122).Mass()
+massDstar = TDatabasePDG.Instance().GetParticle(413).Mass() - TDatabasePDG.Instance().GetParticle(421).Mass()
+massD0 = TDatabasePDG.Instance().GetParticle(421).Mass()
+
+if particleName == 'Dplus':
+    massForFit=massDplus
+elif particleName == 'Ds':
+    massForFit = massDs
+elif particleName == 'Dstar':
+    massForFit = massDstar
+elif particleName == 'D0':
+    massForFit = massD0
+else:
+    massForFit = massLc
+
+canvSizes = [1920, 1080]
+if nPtBins == 1:
+    canvSizes = [500, 500]
+
+nMaxCanvases = 20 # do not put more than 20 bins per canvas to make them visible
+nCanvases = int(np.ceil(nPtBins / nMaxCanvases))
+cMass, cResiduals = [], []
+for iCanv in range(nCanvases):
+    nPads = nPtBins if nCanvases == 1 else nMaxCanvases
+    cMass.append(TCanvas(f'cMass{iCanv}', f'cMass{iCanv}', canvSizes[0], canvSizes[1]))
+    DivideCanvas(cMass[iCanv], nPads)
+    cResiduals.append(TCanvas(f'cResiduals{iCanv}', f'cResiduals{iCanv}', canvSizes[0], canvSizes[1]))
+    DivideCanvas(cResiduals[iCanv], nPads)
+
+cSimFit = []
+for i in range(nPtBins):
+    ptLow = ptMins[i]
+    ptHigh = ptMaxs[i]
+    cSimFit.append(TCanvas(f'cSimFit_Pt{ptLow}_{ptHigh}', f'cSimFit_Pt{ptLow}_{ptHigh}', 400, 900))
+    #DivideCanvas(cSimFit[iCanv], nPads)
+print('cSimFit', cSimFit)
+
+massFitter, vnFitter = [], []
+
+rebins = fitConfig['Rebin']
+if not isinstance(rebins, list):
+    rebins = [rebins] * len(ptMins)
+
+massMins = fitConfig['MassMin']
+if not isinstance(massMins, list):
+    massMins = [massMins] * len(ptMins)
+
+massMaxs = fitConfig['MassMax']
+if not isinstance(massMaxs, list):
+    massMaxs = [massMaxs] * len(ptMins)
+
+for iPt, (hM, hV, ptMin, ptMax, reb, sgnEnum, bkgEnum, bkgVnEnum, secPeak, massMin, massMax) in enumerate(
+        zip(hMass, hVn, ptMins, ptMaxs, rebins, SgnFunc, BkgFunc, BkgFuncVn, inclSecPeak, massMins, massMaxs)):
+    iCanv = int(np.floor(iPt / nMaxCanvases))
+    hMassForFit.append(TH1F())
+    hVnForFit.append(TH1F())
+    AliVertexingHFUtils.RebinHisto(hM, reb).Copy(hMassForFit[iPt]) #to cast TH1D to TH1F
+    hMassForFit[iPt].SetDirectory(0)
+    xbins = np.asarray(hV.GetXaxis().GetXbins())
+    hDummy = TH1F('hDummy', '', len(xbins)-1, xbins)
+    for iBin in range(1, hV.GetNbinsX()+1):
+        hDummy.SetBinContent(iBin, hV.GetBinContent(iBin))
+        hDummy.SetBinError(iBin, hV.GetBinError(iBin))
+    hVnForFit[iPt] = hDummy
+    hVnForFit[iPt].SetDirectory(0)
+    binWidth = hMassForFit[iPt].GetBinWidth(1)
+    hMassForFit[iPt].SetTitle((f'{ptMin:0.1f} < #it{{p}}_{{T}} < {ptMax:0.1f} GeV/#it{{c}};{massAxisTit};'
+                               f'Counts per {binWidth*1000:.0f} MeV/#it{{c}}^{{2}}'))
+    hMassForFit[iPt].SetName(f'MassForFit{iPt}')
+    if not args.isMC and enableRef:
+        hMassForRel.append(TH1F())
+        hMassForSig.append(TH1F())
+        AliVertexingHFUtils.RebinHisto(hRel[iPt], reb).Copy(hMassForRel[iPt])
+        AliVertexingHFUtils.RebinHisto(hSig[iPt], reb).Copy(hMassForSig[iPt])
+    if nPtBins < 15:
+        markerSize = 1.
+    else:
+        markerSize = 0.5
+    SetObjectStyle(hMassForFit[iPt], color=kBlack, markerstyle=kFullCircle, markersize=markerSize)
+    SetObjectStyle(hVnForFit[iPt], color=kBlack, markerstyle=kFullCircle, markersize=markerSize)
+
+    # MC
+    if args.isMC:
+        parRawYield, parMean, parSigma1 = 0, 1, 2 # always the same
+        parSigma2, parFrac2Gaus, parRawYieldSecPeak, parMeanSecPeak, parSigmaSecPeak = (-1 for _ in range(5))
+
+        if sgnEnum == AliHFInvMassFitter.kGaus:
+            if not (secPeak and particleName == 'Ds'):
+                massFunc = TF1(f'massFunc{iPt}', SingleGaus, massMin, massMax, 3)
+                massFunc.SetParameters(hMassForFit[iPt].Integral() * binWidth, massForFit, 0.010)
+            else:
+                massFunc = TF1(f'massFunc{iPt}', DoublePeakSingleGaus, massMin, massMax, 6)
+                massFunc.SetParameters(hMassForFit[iPt].Integral() * binWidth, massForFit, 0.010,
+                                       hMassForFit[iPt].Integral() * binWidth, massDplus, 0.010)
+                parRawYieldSecPeak = 3
+                parMeanSecPeak = 4
+                parSigmaSecPeak = 5
+
+        elif sgnEnum == AliHFInvMassFitter.k2Gaus:
+            parSigma2 = 3
+            parFrac2Gaus = 4
+            if not (secPeak and particleName == 'Ds'):
+                massFunc = TF1(f'massFunc{iPt}', DoubleGaus, massMin, massMax, 5)
+                if not particleName == 'Dstar':
+                    massFunc.SetParameters(hMassForFit[iPt].Integral() * binWidth, massForFit, 0.010, 0.030, 0.9)
+                else:
+                    massFunc.SetParameters(hMassForFit[iPt].Integral() * binWidth, massForFit, 0.0010, 0.0030, 0.9)
+            else:
+                massFunc = TF1(f'massFunc{iPt}', DoublePeakDoubleGaus, massMin, massMax, 8)
+                massFunc.SetParameters(hMassForFit[iPt].Integral() * binWidth, massForFit, 0.010, 0.030, 0.9,
+                                       hMassForFit[iPt].Integral() * binWidth, massDplus, 0.010)
+                parRawYieldSecPeak = 5
+                parMeanSecPeak = 6
+                parSigmaSecPeak = 7
+        else:
+            print("ERROR: Only kGaus and k2Gaus are supported for MC. Exit!") #TODO: add support for k2GausSigmaRatioPar
+            sys.exit()
+
+        if nPtBins > 1:
+            cMass[iCanv].cd(iPt-nMaxCanvases*iCanv+1)
+        else:
+            cMass[iCanv].cd()
+        hMassForFit[iPt].Fit(massFunc, 'E')  # fit with chi2
+
+        rawyield = massFunc.GetParameter(parRawYield)
+        rawyielderr = massFunc.GetParError(parRawYield)
+        sigma = massFunc.GetParameter(parSigma1)
+        sigmaerr = massFunc.GetParError(parSigma1)
+        mean = massFunc.GetParameter(parMean)
+        meanerr = massFunc.GetParError(parMean)
+        redchi2 = massFunc.GetChisquare() / massFunc.GetNDF()
+
+        hRawYields.SetBinContent(iPt+1, rawyield)
+        hRawYields.SetBinError(iPt+1, rawyielderr)
+        hRawYieldsSigma.SetBinContent(iPt+1, sigma)
+        hRawYieldsSigma.SetBinError(iPt+1, sigmaerr)
+        hRawYieldsMean.SetBinContent(iPt+1, mean)
+        hRawYieldsMean.SetBinError(iPt+1, meanerr)
+        hRawYieldsChiSquare.SetBinContent(iPt+1, redchi2)
+        hRawYieldsChiSquare.SetBinError(iPt+1, 0.)
+
+        hRawYieldsTrue.SetBinContent(iPt+1, hMassForFit[iPt].Integral())
+        hRawYieldsTrue.SetBinError(iPt+1, np.sqrt(hMassForFit[iPt].Integral()))
+        hRelDiffRawYieldsFitTrue.SetBinContent(iPt+1, rawyield-hMassForFit[iPt].Integral())
+        hRelDiffRawYieldsFitTrue.SetBinError(iPt+1, np.sqrt(rawyielderr*rawyielderr+hMassForFit[iPt].Integral()))
+
+        if secPeak and particleName == 'Ds':
+            rawyieldSecPeak = massFunc.GetParameter(parRawYieldSecPeak)
+            rawyieldSecPeakerr = massFunc.GetParError(parRawYieldSecPeak)
+            sigmaSecPeak = massFunc.GetParameter(parSigmaSecPeak)
+            sigmaSecPeakerr = massFunc.GetParError(parSigmaSecPeak)
+            meanSecPeak = massFunc.GetParameter(parMeanSecPeak)
+            meanSecPeakerr = massFunc.GetParError(parMeanSecPeak)
+            hRawYieldsSecPeak.SetBinContent(iPt+1, rawyieldSecPeak)
+            hRawYieldsSecPeak.SetBinError(iPt+1, rawyieldSecPeakerr)
+            hRawYieldsMeanSecPeak.SetBinContent(iPt+1, meanSecPeak)
+            hRawYieldsMeanSecPeak.SetBinError(iPt+1, meanSecPeakerr)
+            hRawYieldsSigmaSecPeak.SetBinContent(iPt+1, sigmaSecPeak)
+            hRawYieldsSigmaSecPeak.SetBinError(iPt+1, sigmaSecPeakerr)
+            hRawYieldsSigmaRatioSecondFirstPeak.SetBinContent(iPt+1, sigmaSecPeak/sigma)
+            hRawYieldsSigmaRatioSecondFirstPeak.SetBinError(iPt+1, \
+                np.sqrt(sigmaerr**2/sigma**2+sigmaSecPeakerr**2/sigmaSecPeak**2)*sigmaSecPeak/sigma)
+
+            hRawYieldsSecPeakTrue.SetBinContent(iPt+1, rawyield)
+            hRelDiffRawYieldsSecPeakFitTrue.SetBinContent(iPt+1, rawyield)
+
+        if sgnEnum == AliHFInvMassFitter.k2Gaus:
+            sigma2 = massFunc.GetParameter(parSigma2)
+            sigma2err = massFunc.GetParError(parSigma2)
+            frac2gaus = massFunc.GetParameter(parFrac2Gaus)
+            frac2gauserr = massFunc.GetParError(parFrac2Gaus)
+            hRawYieldsSigma2.SetBinContent(iPt+1, sigma2)
+            hRawYieldsSigma2.SetBinError(iPt+1, sigma2err)
+            hRawYieldsFracGaus2.SetBinContent(iPt+1, frac2gaus)
+            hRawYieldsFracGaus2.SetBinError(iPt+1, frac2gauserr)
+
+    else:  # data
+        massFitter.append(AliHFInvMassFitter(hMassForFit[iPt], massMin, massMax, bkgEnum, sgnEnum))
+        if degPol[iPt] > 0:
+            massFitter[iPt].SetPolDegreeForBackgroundFit(degPol[iPt])
+
+        if fitConfig['UseLikelihood']:
+            massFitter[iPt].SetUseLikelihoodFit()
+        if fixMean[iPt]:
+            massFitter[iPt].SetFixGaussianMean(hMeanToFix.GetBinContent(iPt+1))
+        if fitConfig['BoundMean']:
+            massFitter[iPt].SetBoundGaussianMean(massForFit, massMin, massMax)
+        else:
+            massFitter[iPt].SetInitialGaussianMean(massForFit)
+        if fitConfig['FixSigmaRatio']:
+            massFitter[iPt].SetFixRatio2GausSigma(
+                hSigmaToFix.GetBinContent(iPt+1)/hSigmaToFix2.GetBinContent(iPt+1))
+
+        if fixSigma[iPt]:
+            if isinstance(fitConfig['SigmaMultFactor'], (float, int)):
+                massFitter[iPt].SetFixGaussianSigma(
+                    hSigmaToFix.GetBinContent(iPt+1)*fitConfig['SigmaMultFactor'])
+            else:
+                if fitConfig['SigmaMultFactor'] == 'MinusUnc':
+                    massFitter[iPt].SetFixGaussianSigma(
+                        hSigmaToFix.GetBinContent(iPt+1)-hSigmaToFix.GetBinError(iPt+1))
+                elif fitConfig['SigmaMultFactor'] == 'PlusUnc':
+                    massFitter[iPt].SetFixGaussianSigma(
+                        hSigmaToFix.GetBinContent(iPt+1)+hSigmaToFix.GetBinError(iPt+1))
+                else:
+                    print('WARNING: impossible to fix sigma! Wrong mult factor set in config file!')
+        else:
+            if hSigmaToFix:
+                massFitter[iPt].SetInitialGaussianSigma(
+                    hSigmaToFix.GetBinContent(iPt+1)*fitConfig['SigmaMultFactor'])
+            else:
+                if particleName == 'Dstar':
+                    massFitter[iPt].SetInitialGaussianSigma(0.001)
+                else:
+                    massFitter[iPt].SetInitialGaussianSigma(0.008)
+
+        if secPeak and particleName == 'Ds':
+            if hSigmaToFixSecPeak:
+                sigmaToFix = hSigmaToFixSecPeak.GetBinContent(iPt+1) * fitConfig['SigmaMultFactorSecPeak']
+                massFitter[iPt].IncludeSecondGausPeak(massDplus, False, sigmaToFix, True)
+                if fitConfig['FixSigmaToFirstPeak']:
+                    # fix D+ peak to sigmaMC(D+)/sigmaMC(Ds+)*sigmaData(Ds+)
+                    massFitter[iPt].MassFitter(False)
+                    sigmaFirstPeak = massFitter[iPt].GetSigma()
+                    sigmaRatioMC = hSigmaToFixSecPeak.GetBinContent(iPt+1) / hSigmaFirstPeakMC.GetBinContent(iPt+1)
+                    massFitter[iPt].IncludeSecondGausPeak(massDplus, False, sigmaRatioMC * sigmaFirstPeak, True)
+            else:
+                massFitter[iPt].IncludeSecondGausPeak(massDplus, False, fitConfig['SigmaSecPeak'][iPt], True)
+        if enableRef:
+            rOverS = hMassForSig[iPt].Integral(
+                hMassForSig[iPt].FindBin(massMin * 1.0001),
+                hMassForSig[iPt].FindBin(massMax * 0.999)
+            )
+            rOverS = hMassForRel[iPt].Integral(
+                hMassForRel[iPt].FindBin(massMin * 1.0001),
+                hMassForRel[iPt].FindBin(massMax * 0.999) / rOverS
+            )
+            massFitter[iPt].SetFixReflOverS(rOverS)
+            massFitter[iPt].SetTemplateReflections(hRel[iPt], "2gaus", massMin, massMax)
+        massFitter[iPt].MassFitter(False)
+
+        rawyield = massFitter[iPt].GetRawYield()
+        rawyielderr = massFitter[iPt].GetRawYieldError()
+        sigma = massFitter[iPt].GetSigma()
+        sigmaerr = massFitter[iPt].GetSigmaUncertainty()
+        mean = massFitter[iPt].GetMean()
+        meanerr = massFitter[iPt].GetMeanUncertainty()
+        redchi2 = massFitter[iPt].GetReducedChiSquare()
+        signif, signiferr = ctypes.c_double(), ctypes.c_double()
+        sgn, sgnerr = ctypes.c_double(), ctypes.c_double()
+        bkg, bkgerr = ctypes.c_double(), ctypes.c_double()
+        massFitter[iPt].Significance(3, signif, signiferr)
+        massFitter[iPt].Signal(3, sgn, sgnerr)
+        massFitter[iPt].Background(3, bkg, bkgerr)
+
+        vnFitter.append(AliHFVnVsMassFitter(hMassForFit[iPt], hVnForFit[iPt], massMin, massMax, bkgEnum, sgnEnum, bkgVnEnum))
+        vnFitter[iPt].SetHarmonic(2) # TODO: add possibility to set harmonic in config file
+        vnFitter[iPt].SetInitialGaussianMean(massForFit, 1)
+        vnFitter[iPt].SetInitialGaussianSigma(sigma, 1)
+        if secPeak and particleName == 'Ds':
+            vnFitter[iPt].IncludeSecondGausPeak(massDplus, False, 0.010)
+        #if useRefl:
+        #    vnFitter[iPt].SetTemplateReflections(hRel[iPt], reflopt, massMin, massMax)
+        #    vnFitter[iPt].SetFixReflOverS(SoverR)
+        #    vnFitter[iPt].SetReflVnOption(AliHFVnVsMassFitter.kSameVnSignal)
+
+        vnFitter[iPt].SimultaneusFit(False)
+        hSigmaSimFit.SetBinContent(iPt+1, vnFitter[iPt].GetSigma())
+        hSigmaSimFit.SetBinError(iPt+1, vnFitter[iPt].GetSigmaUncertainty())
+        hMeanSimFit.SetBinContent(iPt+1, vnFitter[iPt].GetMean())
+        hMeanSimFit.SetBinError(iPt+1, vnFitter[iPt].GetMeanUncertainty())
+        hRedChi2SimFit.SetBinContent(iPt+1, vnFitter[iPt].GetReducedChiSquare())
+        hRedChi2SimFit.SetBinError(iPt+1, 1.e-20)
+        hProbSimFit.SetBinContent(iPt+1, vnFitter[iPt].GetFitProbability())
+        hProbSimFit.SetBinError(iPt+1, 1.e-20)
+        hRedChi2SBVnPrefit.SetBinContent(iPt+1, vnFitter[iPt].GetSBVnPrefitReducedChiSquare())
+        hRedChi2SBVnPrefit.SetBinError(iPt+1, 1.e-20)
+        hProbSBVnPrefit.SetBinContent(iPt+1, vnFitter[iPt].GetSBVnPrefitProbability())
+        hProbSBVnPrefit.SetBinError(iPt+1, 1.e-20)
+        vnSimFit = vnFitter[iPt].GetVn()
+        vnSimFitUnc = vnFitter[iPt].GetVnUncertainty()
+        print(f'vnSimFit = {vnSimFit} +- {vnSimFitUnc}')
+        gvnSimFit.SetPoint(iPt, (ptMin+ptMax)/2, vnSimFit)
+        gvnSimFit.SetPointError(iPt, (ptMax-ptMin)/2, (ptMax-ptMin)/2, vnSimFitUnc, vnSimFitUnc)
+
+        if vnSimFit != 0:
+            cSimFit[iPt].cd()
+            vnFitter[iPt].DrawHere(gPad)
+
+        hRawYields.SetBinContent(iPt+1, rawyield)
+        hRawYields.SetBinError(iPt+1, rawyielderr)
+        hRawYieldsSigma.SetBinContent(iPt+1, sigma)
+        hRawYieldsSigma.SetBinError(iPt+1, sigmaerr)
+        hRawYieldsMean.SetBinContent(iPt+1, mean)
+        hRawYieldsMean.SetBinError(iPt+1, meanerr)
+        hRawYieldsSignificance.SetBinContent(iPt+1, signif.value)
+        hRawYieldsSignificance.SetBinError(iPt+1, signiferr.value)
+        hRawYieldsSoverB.SetBinContent(iPt+1, sgn.value/bkg.value)
+        if bkg.value != 0 and sgn.value != 0:
+            hRawYieldsSoverB.SetBinError(iPt+1, sgn.value/bkg.value*np.sqrt(
+                sgnerr.value**2/sgn.value**2+bkgerr.value**2/bkg.value**2))
+        hRawYieldsSignal.SetBinContent(iPt+1, sgn.value)
+        hRawYieldsSignal.SetBinError(iPt+1, sgnerr.value)
+        hRawYieldsBkg.SetBinContent(iPt+1, bkg.value)
+        hRawYieldsBkg.SetBinError(iPt+1, bkgerr.value)
+        hRawYieldsChiSquare.SetBinContent(iPt+1, redchi2)
+        hRawYieldsChiSquare.SetBinError(iPt+1, 1.e-20)
+
+        for iS, _ in enumerate(nSigma4SandB):
+            massFitter[iPt].Significance(nSigma4SandB[iS],signif,signiferr)
+            massFitter[iPt].Signal(nSigma4SandB[iS],sgn,sgnerr)
+            massFitter[iPt].Background(nSigma4SandB[iS],bkg,bkgerr)
+
+            hRawYieldsSignalDiffSigma[iS].SetBinContent(iPt+1,sgn.value)
+            hRawYieldsSignalDiffSigma[iS].SetBinError(iPt+1,sgnerr.value)
+            hRawYieldsBkgDiffSigma[iS].SetBinContent(iPt+1,bkg.value)
+            hRawYieldsBkgDiffSigma[iS].SetBinError(iPt+1,bkgerr.value)
+            hRawYieldsSoverBDiffSigma[iS].SetBinContent(iPt+1,sgn.value/bkg.value)
+            #hRawYieldsSoverBDiffSigma[iS].SetBinError(
+            #    iPt+1,
+            #    sgn.value/bkg.value*np.sqrt(sgnerr.value**2/sgn.value**2+bkgerr.value**2/bkg.value**2)
+            #)
+            hRawYieldsSignifDiffSigma[iS].SetBinContent(iPt+1,signif.value)
+            hRawYieldsSignifDiffSigma[iS].SetBinError(iPt+1,signiferr.value)
+
+        fTotFunc = massFitter[iPt].GetMassFunc()
+        fBkgFunc = massFitter[iPt].GetBackgroundRecalcFunc()
+
+        parFrac2Gaus, parsecondsigma = -1, -1
+        if sgnEnum == AliHFInvMassFitter.k2Gaus:
+            if not (inclSecPeak and particleName == 'Ds'):
+                parFrac2Gaus = fTotFunc.GetNpar()-2
+                parsecondsigma = fTotFunc.GetNpar()-1
+            else:
+                parFrac2Gaus = fTotFunc.GetNpar()-5
+                parsecondsigma = fTotFunc.GetNpar()-4
+
+            sigma2 = fTotFunc.GetParameter(parsecondsigma)
+            sigma2err = fTotFunc.GetParError(parsecondsigma)
+            frac2gaus = fTotFunc.GetParameter(parFrac2Gaus)
+            frac2gauserr = fTotFunc.GetParError(parFrac2Gaus)
+            hRawYieldsSigma2.SetBinContent(iPt+1, sigma2)
+            hRawYieldsSigma2.SetBinError(iPt+1, sigma2err)
+            hRawYieldsFracGaus2.SetBinContent(iPt+1, frac2gaus)
+            hRawYieldsFracGaus2.SetBinError(iPt+1, frac2gauserr)
+
+        if inclSecPeak and particleName == 'Ds':
+            paryieldSecPeak = fTotFunc.GetNpar()-3
+            parMeanSecPeak = fTotFunc.GetNpar()-2
+            parSigmaSecPeak = fTotFunc.GetNpar()-1
+
+            rawyieldSecPeak = fTotFunc.GetParameter(paryieldSecPeak) / binWidth
+            rawyieldSecPeakerr = fTotFunc.GetParError(paryieldSecPeak) / binWidth
+            meanSecPeak = fTotFunc.GetParameter(parMeanSecPeak)
+            meanSecPeakerr = fTotFunc.GetParError(parMeanSecPeak)
+            sigmaSecPeak = fTotFunc.GetParameter(parSigmaSecPeak)
+            sigmaSecPeakerr = fTotFunc.GetParError(parSigmaSecPeak)
+
+            bkgSecPeak = fBkgFunc.Integral(meanSecPeak - 3*sigmaSecPeak, meanSecPeak + 3*sigmaSecPeak) / binWidth
+            bkgSecPeakerr = np.sqrt(bkgSecPeak)
+            signalSecPeak = fTotFunc.Integral(meanSecPeak - 3*sigmaSecPeak, meanSecPeak + 3*sigmaSecPeak) / binWidth \
+                            - bkgSecPeak
+            signalSecPeakerr = np.sqrt(signalSecPeak+bkgSecPeak)
+            signifSecPeak, signifSecPeakerr = ctypes.c_double(), ctypes.c_double()
+            AliVertexingHFUtils.ComputeSignificance(signalSecPeak, signalSecPeakerr, bkgSecPeak, bkgSecPeakerr,
+                                                    signifSecPeak, signifSecPeakerr)
+
+            hRawYieldsSecPeak.SetBinContent(iPt+1, rawyieldSecPeak)
+            hRawYieldsSecPeak.SetBinError(iPt+1, rawyieldSecPeakerr)
+            hRawYieldsMeanSecPeak.SetBinContent(iPt+1, meanSecPeak)
+            hRawYieldsMeanSecPeak.SetBinError(iPt+1, meanSecPeakerr)
+            hRawYieldsSigmaSecPeak.SetBinContent(iPt+1, sigmaSecPeak)
+            hRawYieldsSigmaSecPeak.SetBinError(iPt+1, sigmaSecPeakerr)
+            hRawYieldsSignificanceSecPeak.SetBinContent(iPt+1, signifSecPeak.value)
+            hRawYieldsSignificanceSecPeak.SetBinError(iPt+1, signifSecPeakerr.value)
+            hRawYieldsSigmaRatioSecondFirstPeak.SetBinContent(iPt+1, sigmaSecPeak/sigma)
+            hRawYieldsSigmaRatioSecondFirstPeak.SetBinError(iPt+1, \
+                np.sqrt(sigmaerr**2/sigma**2+sigmaSecPeakerr**2/sigmaSecPeak**2)*sigmaSecPeak/sigma)
+            hRawYieldsSoverBSecPeak.SetBinContent(iPt+1, signalSecPeak/bkgSecPeak)
+            hRawYieldsSoverBSecPeak.SetBinError(iPt+1, \
+                signalSecPeak/bkgSecPeak*np.sqrt(signalSecPeakerr**2/signalSecPeak**2+bkgSecPeakerr**2/bkgSecPeak**2))
+            hRawYieldsSignalSecPeak.SetBinContent(iPt+1, signalSecPeak)
+            hRawYieldsSignalSecPeak.SetBinError(iPt+1, signalSecPeakerr)
+            hRawYieldsBkgSecPeak.SetBinContent(iPt+1, bkgSecPeak)
+            hRawYieldsBkgSecPeak.SetBinError(iPt+1, bkgSecPeakerr)
+
+        if nPtBins > 1:
+            cMass[iCanv].cd(iPt-nMaxCanvases*iCanv+1)
+        else:
+            cMass[iCanv].cd()
+
+        hMassForFit[iPt].GetYaxis().SetRangeUser(hMassForFit[iPt].GetMinimum()*0.95, hMassForFit[iPt].GetMaximum()*1.2)
+        massFitter[iPt].GetSignalFunc().SetNpx(500)
+        massFitter[iPt].GetMassFunc().SetNpx(500)
+
+        massFitter[iPt].DrawHere(gPad)
+
+        # residuals
+        if nPtBins > 1:
+            cResiduals[iCanv].cd(iPt-nMaxCanvases*iCanv+1)
+        else:
+            cResiduals[iCanv].cd()
+        massFitter[iPt].DrawHistoMinusFit(gPad)
+
+    cMass[iCanv].Modified()
+    cMass[iCanv].Update()
+    cResiduals[iCanv].Modified()
+    cResiduals[iCanv].Update()
+    cSimFit[iCanv].Modified()
+    cSimFit[iCanv].Update()
+
+#save output histos
+print(f'Saving output to {args.outputdir}')
+for icanv, canv in enumerate(cSimFit):
+    canv.SaveAs(f'{args.outputdir}/SimFit{args.suffix}_{particleName}_{icanv}.pdf')
+outfile_name = f'{args.outputdir}/raw_yields{args.suffix}.root'
+outFile = TFile(outfile_name, 'recreate')
+for canv in cMass:
+    canv.Write()
+if not args.isMC:
+    for canv in cResiduals:
+        canv.Write()
+for hist in hMass:
+    hist.Write()
+for fitter, ptLow, ptHigh in zip(massFitter, ptMins, ptMaxs):
+    fitter.GetMassFunc().SetName(f'fTot_{ptLow}_{ptHigh}')
+    fitter.GetSignalFunc().SetName(f'fSgn_{ptLow}_{ptHigh}')
+    fitter.GetBackgroundRecalcFunc().SetName(f'fBkg_{ptLow}_{ptHigh}')
+    fitter.GetMassFunc().Write()
+    fitter.GetSignalFunc().Write()
+    fitter.GetBackgroundRecalcFunc().Write()
+hRawYields.Write()
+hRawYieldsSigma.Write()
+hRawYieldsMean.Write()
+hRawYieldsSignificance.Write()
+hRawYieldsSoverB.Write()
+hRawYieldsSignal.Write()
+hRawYieldsBkg.Write()
+hRawYieldsChiSquare.Write()
+hRawYieldsSigma2.Write()
+hRawYieldsFracGaus2.Write()
+hRawYieldsSecPeak.Write()
+hRawYieldsMeanSecPeak.Write()
+hRawYieldsSigmaSecPeak.Write()
+hRawYieldsSignificanceSecPeak.Write()
+hRawYieldsSigmaRatioSecondFirstPeak.Write()
+hRawYieldsSoverBSecPeak.Write()
+hRawYieldsSignalSecPeak.Write()
+hRawYieldsBkgSecPeak.Write()
+hRawYieldsTrue.Write()
+hRawYieldsSecPeakTrue.Write()
+hRelDiffRawYieldsFitTrue.Write()
+hRelDiffRawYieldsSecPeakFitTrue.Write()
+gvnSimFit.Write()
+hMeanSimFit.Write()
+hRedChi2SimFit.Write()
+hProbSimFit.Write()
+hRedChi2SBVnPrefit.Write()
+hProbSBVnPrefit.Write()
+hEv.Write()
+if not args.isMC:
+    dirSB = TDirectoryFile('SandBDiffNsigma', 'SandBDiffNsigma')
+    dirSB.Write()
+    dirSB.cd()
+    for iS, _ in enumerate(nSigma4SandB):
+        hRawYieldsSignalDiffSigma[iS].Write()
+        hRawYieldsBkgDiffSigma[iS].Write()
+        hRawYieldsSoverBDiffSigma[iS].Write()
+        hRawYieldsSignifDiffSigma[iS].Write()
+    dirSB.Close()
+outFile.Close()
+
+outFileNamePDF = outfile_name.replace('.root', '.pdf')
+outFileNameResPDF = outFileNamePDF.replace('.pdf', '_Residuals.pdf')
+for iCanv, (cM, cR) in enumerate(zip(cMass, cResiduals)):
+    if iCanv == 0 and nCanvases > 1:
+        cM.SaveAs(f'{outFileNamePDF}[')
+    cM.SaveAs(outFileNamePDF)
+    if iCanv == nCanvases-1 and nCanvases > 1:
+        cM.SaveAs(f'{outFileNamePDF}]')
+    if not args.isMC:
+        if iCanv == 0 and nCanvases > 1:
+            cR.SaveAs(f'{outFileNameResPDF}[')
+        cR.SaveAs(outFileNameResPDF)
+        if iCanv == nCanvases-1 and nCanvases > 1:
+            cR.SaveAs(f'{outFileNameResPDF}]')
+
+if not args.batch:
+    input('Press enter to exit')

--- a/run3/flow/project_thnsparse.py
+++ b/run3/flow/project_thnsparse.py
@@ -2,9 +2,8 @@ import ROOT
 import yaml
 import argparse
 import numpy as np
-import sys
 from alive_progress import alive_bar
-from flow_analysis_utils import get_vn_versus_mass
+from flow_analysis_utils import get_vn_versus_mass, get_centrality_bins
 
 def compute_r2(reso_file, cent_min, cent_max, detA, detB, detC, do_ep):
 
@@ -12,12 +11,7 @@ def compute_r2(reso_file, cent_min, cent_max, detA, detB, detC, do_ep):
         hist_name = 'hf-task-flow-charm-hadrons/epReso/hEpReso'
     else:
         hist_name = 'hf-task-flow-charm-hadrons/spReso/hSpReso'
-    
-    print(f'Computing resolution for {detA}, {detB}, {detC}')
-    print(f'Centrality bin: {cent_min} - {cent_max}')
-    print(f'Hist name: {hist_name}{detA}{detB}')
-    print(f'Hist name: {hist_name}{detA}{detC}')
-    print(f'Hist name: {hist_name}{detB}{detC}')
+
     detA_detB = reso_file.Get(f'{hist_name}{detA}{detB}')
     detA_detC = reso_file.Get(f'{hist_name}{detA}{detC}')
     detB_detC = reso_file.Get(f'{hist_name}{detB}{detC}')
@@ -33,16 +27,17 @@ def compute_r2(reso_file, cent_min, cent_max, detA, detB, detC, do_ep):
     average_detA_detC = proj_detA_detC.GetMean()
     average_detB_detC = proj_detB_detC.GetMean()
 
-    reso = np.sqrt((average_detA_detB * average_detA_detC) / average_detB_detC) if average_detB_detC > 0 else 1.e+100000
+    reso = (average_detA_detB * average_detA_detC) / average_detB_detC if average_detB_detC != 0 else -999
+    reso = np.sqrt(reso) if reso > 0 else -999
     return reso
 
-def check_anres(config, an_res_file, outputdir, suffix, do_ep):
+def check_anres(config, an_res_file, centrality, outputdir, suffix, do_ep):
     with open(config, 'r') as ymlCfgFile:
         config = yaml.load(ymlCfgFile, yaml.FullLoader)
 
     pt_mins = config['ptmins']
     pt_maxs = config['ptmaxs']
-    cent_bins = config['centrality_bins']
+    _, cent_bins = get_centrality_bins(centrality)
     det_A = config['detA']
     det_B = config['detB']
     det_C = config['detC']
@@ -51,59 +46,49 @@ def check_anres(config, an_res_file, outputdir, suffix, do_ep):
     axis_mass = config['axes']['mass']
     axis_sp = config['axes']['sp']
     axis_deltaphi = config['axes']['deltaphi']
-    meson = config['Dmeson']
-    #axis_bdt_bkg = config['axes']['bdt_bkg']
+    inv_mass_bins = config['inv_mass_bins']
+    #axis_bdt_bkg = config['axes']['bdt_bkg'] #TODO: add BDT selections
     #axis_bdt_sig = config['axes']['bdt_sig']
 
-    # TODO: move this to the config file
-    if meson == 'Dplus':
-        inv_mass_bins = [1.74, 1.78, 1.82, 1.84, 1.85, 1.86, 1.87, 1.88, 1.89, 1.90, 1.92, 1.96, 2.00]
-        #[1.74, 1.75, 1.76, 1.77, 1.78, 1.79, 1.80, 1.81, 1.82, 1.83, 1.835, 1.84, 1.845, 1.85, 1.855, 1.86, 1.865, 1.87, 1.875, 1.88, 1.885, 1.89, 1.895, 1.90, 1.905, 1.91, 1.915, 1.92, 1.93, 1.94, 1.95, 1.96, 1.97, 1.98, 1.99, 2.00]
-    elif meson == 'Ds':
-        inv_mass_bins = [1.8, 1.82, 1.84, 1.86, 1.88, 1.90, 1.92, 1.94, 1.96, 1.98, 2.00, 2.02, 2.04, 2.06, 2.08, 2.10]
-        
     infile = ROOT.TFile(an_res_file, 'READ')
     thnsparse = infile.Get('hf-task-flow-charm-hadrons/hSparseFlowCharm')
 
     outfile = ROOT.TFile(f'{outputdir}/proj{suffix}.root', 'RECREATE')
     hist_reso = ROOT.TH1F('hist_reso', 'hist_reso', len(cent_bins) - 1, cent_bins[0], cent_bins[-1])
-    for _, (cent_min, cent_max) in enumerate(zip(cent_bins[:-1], cent_bins[1:])):
-        thnsparse_selcent = thnsparse.Clone(f'thnsparse_selcent{cent_min}_{cent_max}')
-        thnsparse_selcent.GetAxis(axis_cent).SetRangeUser(cent_min, cent_max)
-        reso = compute_r2(infile, cent_min, cent_max, det_A, det_B, det_C, do_ep)
-        hist_reso.SetBinContent(hist_reso.FindBin(cent_min), reso)
+    cent_min = cent_bins[0]
+    cent_max = cent_bins[1]
+    thnsparse_selcent = thnsparse.Clone(f'thnsparse_selcent{cent_min}_{cent_max}')
+    thnsparse_selcent.GetAxis(axis_cent).SetRangeUser(cent_min, cent_max)
+    reso = compute_r2(infile, cent_min, cent_max, det_A, det_B, det_C, do_ep)
+    hist_reso.SetBinContent(hist_reso.FindBin(cent_min), reso)
 
-        with alive_bar(len(pt_mins)) as bar:
-            for _, (pt_min, pt_max) in enumerate(zip(pt_mins, pt_maxs)):
-                print(f'Processing pt bin {pt_min} - {pt_max}')
-                #if meson == 'Dplus':
-                    #if pt_min >= 4:
-                inv_mass_bins = [1.74, 1.78, 1.82, 1.84, 1.85, 1.86, 1.87, 1.88, 1.89, 1.90, 1.92, 1.96, 2.00]
-                    #else:
-                    #inv_mass_bins = [1.74, 1.77, 1.80, 1.81, 1.82, 1.83, 1.835, 1.84, 1.845, 1.85, 1.855, 1.86, 1.865, 1.87, 1.875, 1.88, 1.885, 1.89, 1.895, 1.90, 1.905, 1.91, 1.915, 1.92, 1.93, 1.96, 1.99, 2.00]
-                outfile.mkdir(f'cent_bins{cent_min}_{cent_max}/pt_bins{pt_min}_{pt_max}')
-                thnsparse_selcent.GetAxis(axis_pt).SetRangeUser(pt_min, pt_max)
-                
-                if do_ep:
-                    hist_vn_ep = get_vn_versus_mass(thnsparse_selcent, inv_mass_bins,
-                                                    axis_mass, axis_deltaphi, False)
-                    hist_vn_ep.SetName(f'hist_vn_ep_pt{pt_min}_{pt_max}')
-                    hist_vn_ep.SetDirectory(0)
-                    hist_vn_ep.Scale(1./reso)
-                    outfile.cd(f'cent_bins{cent_min}_{cent_max}/pt_bins{pt_min}_{pt_max}')
-                    hist_vn_ep.Write()
-                else:
-                    hist_vn_sp = get_vn_versus_mass(thnsparse_selcent, inv_mass_bins, axis_mass, axis_sp)
-                    hist_vn_sp.SetDirectory(0)
-                    hist_vn_sp.SetName(f'hist_vn_sp_pt{pt_min}_{pt_max}')
-                    hist_vn_sp.Scale(1./reso)
-                    outfile.cd(f'cent_bins{cent_min}_{cent_max}/pt_bins{pt_min}_{pt_max}')
-                    hist_vn_sp.Write()
-                hist_mass = thnsparse_selcent.Projection(axis_mass)
-                hist_mass.SetName(f'hist_mass_cent{cent_min}_{cent_max}_pt{pt_min}_{pt_max}')
-                hist_mass.Write()
-                bar()
-                outfile.cd('..')
+    with alive_bar(len(pt_mins)) as bar:
+        for ipt, (pt_min, pt_max) in enumerate(zip(pt_mins, pt_maxs)):
+            print(f'Processing pt bin {pt_min} - {pt_max}')
+            inv_mass_bin = inv_mass_bins[ipt]
+            outfile.mkdir(f'cent_bins{cent_min}_{cent_max}/pt_bins{pt_min}_{pt_max}')
+            thnsparse_selcent.GetAxis(axis_pt).SetRangeUser(pt_min, pt_max)
+            
+            if do_ep:
+                hist_vn_ep = get_vn_versus_mass(thnsparse_selcent, inv_mass_bin,
+                                                axis_mass, axis_deltaphi, False)
+                hist_vn_ep.SetName(f'hist_vn_ep_pt{pt_min}_{pt_max}')
+                hist_vn_ep.SetDirectory(0)
+                hist_vn_ep.Scale(1./reso)
+                outfile.cd(f'cent_bins{cent_min}_{cent_max}/pt_bins{pt_min}_{pt_max}')
+                hist_vn_ep.Write()
+            else:
+                hist_vn_sp = get_vn_versus_mass(thnsparse_selcent, inv_mass_bin, axis_mass, axis_sp)
+                hist_vn_sp.SetDirectory(0)
+                hist_vn_sp.SetName(f'hist_vn_sp_pt{pt_min}_{pt_max}')
+                hist_vn_sp.Scale(1./reso)
+                outfile.cd(f'cent_bins{cent_min}_{cent_max}/pt_bins{pt_min}_{pt_max}')
+                hist_vn_sp.Write()
+            hist_mass = thnsparse_selcent.Projection(axis_mass)
+            hist_mass.SetName(f'hist_mass_cent{cent_min}_{cent_max}_pt{pt_min}_{pt_max}')
+            hist_mass.Write()
+            bar()
+            outfile.cd('..')
     outfile.cd()
     hist_reso.Write()
     outfile.Close()
@@ -115,6 +100,8 @@ if __name__ == "__main__":
                         default="config.yaml", help="configuration file")
     parser.add_argument("an_res_file", metavar="text",
                         default="an_res.root", help="input ROOT file with anres")
+    parser.add_argument("--centrality", "-c", metavar="text",
+                        default="k3050", help="centrality class")
     parser.add_argument("--outputdir", "-o", metavar="text",
                         default=".", help="output directory")
     parser.add_argument("--suffix", "-s", metavar="text",
@@ -126,6 +113,7 @@ if __name__ == "__main__":
     check_anres(
         config=args.config,
         an_res_file=args.an_res_file,
+        centrality=args.centrality,
         outputdir=args.outputdir,
         suffix=args.suffix,
         do_ep=args.doEP

--- a/run3/flow/project_thnsparse.py
+++ b/run3/flow/project_thnsparse.py
@@ -3,33 +3,7 @@ import yaml
 import argparse
 import numpy as np
 from alive_progress import alive_bar
-from flow_analysis_utils import get_vn_versus_mass, get_centrality_bins
-
-def compute_r2(reso_file, cent_min, cent_max, detA, detB, detC, do_ep):
-
-    if do_ep:
-        hist_name = 'hf-task-flow-charm-hadrons/epReso/hEpReso'
-    else:
-        hist_name = 'hf-task-flow-charm-hadrons/spReso/hSpReso'
-
-    detA_detB = reso_file.Get(f'{hist_name}{detA}{detB}')
-    detA_detC = reso_file.Get(f'{hist_name}{detA}{detC}')
-    detB_detC = reso_file.Get(f'{hist_name}{detB}{detC}')
-
-    cent_bin_min = detA_detB.GetXaxis().FindBin(cent_min)
-    cent_bin_max = detA_detB.GetXaxis().FindBin(cent_max)
-
-    proj_detA_detB = detA_detB.ProjectionY(f'{hist_name}{detA}{detB}_proj{cent_min}_{cent_max}', cent_bin_min, cent_bin_max)
-    proj_detA_detC = detA_detC.ProjectionY(f'{hist_name}{detA}{detC}_proj{cent_min}_{cent_max}', cent_bin_min, cent_bin_max)
-    proj_detB_detC = detB_detC.ProjectionY(f'{hist_name}{detB}{detC}_proj{cent_min}_{cent_max}', cent_bin_min, cent_bin_max)
-
-    average_detA_detB = proj_detA_detB.GetMean()
-    average_detA_detC = proj_detA_detC.GetMean()
-    average_detB_detC = proj_detB_detC.GetMean()
-
-    reso = (average_detA_detB * average_detA_detC) / average_detB_detC if average_detB_detC != 0 else -999
-    reso = np.sqrt(reso) if reso > 0 else -999
-    return reso
+from flow_analysis_utils import get_vn_versus_mass, get_centrality_bins, compute_r2
 
 def check_anres(config, an_res_file, centrality, outputdir, suffix, do_ep):
     with open(config, 'r') as ymlCfgFile:
@@ -47,8 +21,12 @@ def check_anres(config, an_res_file, centrality, outputdir, suffix, do_ep):
     axis_sp = config['axes']['sp']
     axis_deltaphi = config['axes']['deltaphi']
     inv_mass_bins = config['inv_mass_bins']
-    #axis_bdt_bkg = config['axes']['bdt_bkg'] #TODO: add BDT selections
-    #axis_bdt_sig = config['axes']['bdt_sig']
+    axis_bdt_bkg = config['axes']['bdt_bkg']
+    axis_bdt_sig = config['axes']['bdt_sig']
+    apply_btd_cuts = config['apply_btd_cuts']
+    if apply_btd_cuts:
+        bkg_ml_cuts = config['bkg_ml_cuts']
+        sig_ml_cuts = config['sig_ml_cuts']
 
     infile = ROOT.TFile(an_res_file, 'READ')
     thnsparse = infile.Get('hf-task-flow-charm-hadrons/hSparseFlowCharm')
@@ -59,7 +37,7 @@ def check_anres(config, an_res_file, centrality, outputdir, suffix, do_ep):
     cent_max = cent_bins[1]
     thnsparse_selcent = thnsparse.Clone(f'thnsparse_selcent{cent_min}_{cent_max}')
     thnsparse_selcent.GetAxis(axis_cent).SetRangeUser(cent_min, cent_max)
-    reso = compute_r2(infile, cent_min, cent_max, det_A, det_B, det_C, do_ep)
+    reso = 1#compute_r2(infile, cent_min, cent_max, det_A, det_B, det_C, do_ep)
     hist_reso.SetBinContent(hist_reso.FindBin(cent_min), reso)
 
     with alive_bar(len(pt_mins)) as bar:
@@ -68,20 +46,26 @@ def check_anres(config, an_res_file, centrality, outputdir, suffix, do_ep):
             inv_mass_bin = inv_mass_bins[ipt]
             outfile.mkdir(f'cent_bins{cent_min}_{cent_max}/pt_bins{pt_min}_{pt_max}')
             thnsparse_selcent.GetAxis(axis_pt).SetRangeUser(pt_min, pt_max)
+            if apply_btd_cuts:
+                print('Applying BDT cuts')
+                thnsparse_selcent.GetAxis(axis_bdt_bkg).SetRangeUser(0, bkg_ml_cuts[0])
+                thnsparse_selcent.GetAxis(axis_bdt_sig).SetRangeUser(sig_ml_cuts[0], 1)
             
             if do_ep:
                 hist_vn_ep = get_vn_versus_mass(thnsparse_selcent, inv_mass_bin,
                                                 axis_mass, axis_deltaphi, False)
                 hist_vn_ep.SetName(f'hist_vn_ep_pt{pt_min}_{pt_max}')
                 hist_vn_ep.SetDirectory(0)
-                hist_vn_ep.Scale(1./reso)
+                if reso > 0:
+                    hist_vn_ep.Scale(1./reso)
                 outfile.cd(f'cent_bins{cent_min}_{cent_max}/pt_bins{pt_min}_{pt_max}')
                 hist_vn_ep.Write()
             else:
                 hist_vn_sp = get_vn_versus_mass(thnsparse_selcent, inv_mass_bin, axis_mass, axis_sp)
                 hist_vn_sp.SetDirectory(0)
                 hist_vn_sp.SetName(f'hist_vn_sp_pt{pt_min}_{pt_max}')
-                hist_vn_sp.Scale(1./reso)
+                if reso > 0:
+                    hist_vn_sp.Scale(1./reso)
                 outfile.cd(f'cent_bins{cent_min}_{cent_max}/pt_bins{pt_min}_{pt_max}')
                 hist_vn_sp.Write()
             hist_mass = thnsparse_selcent.Projection(axis_mass)

--- a/run3/flow/project_thnsparse.py
+++ b/run3/flow/project_thnsparse.py
@@ -1,0 +1,132 @@
+import ROOT
+import yaml
+import argparse
+import numpy as np
+import sys
+from alive_progress import alive_bar
+from flow_analysis_utils import get_vn_versus_mass
+
+def compute_r2(reso_file, cent_min, cent_max, detA, detB, detC, do_ep):
+
+    if do_ep:
+        hist_name = 'hf-task-flow-charm-hadrons/epReso/hEpReso'
+    else:
+        hist_name = 'hf-task-flow-charm-hadrons/spReso/hSpReso'
+    
+    print(f'Computing resolution for {detA}, {detB}, {detC}')
+    print(f'Centrality bin: {cent_min} - {cent_max}')
+    print(f'Hist name: {hist_name}{detA}{detB}')
+    print(f'Hist name: {hist_name}{detA}{detC}')
+    print(f'Hist name: {hist_name}{detB}{detC}')
+    detA_detB = reso_file.Get(f'{hist_name}{detA}{detB}')
+    detA_detC = reso_file.Get(f'{hist_name}{detA}{detC}')
+    detB_detC = reso_file.Get(f'{hist_name}{detB}{detC}')
+
+    cent_bin_min = detA_detB.GetXaxis().FindBin(cent_min)
+    cent_bin_max = detA_detB.GetXaxis().FindBin(cent_max)
+
+    proj_detA_detB = detA_detB.ProjectionY(f'{hist_name}{detA}{detB}_proj{cent_min}_{cent_max}', cent_bin_min, cent_bin_max)
+    proj_detA_detC = detA_detC.ProjectionY(f'{hist_name}{detA}{detC}_proj{cent_min}_{cent_max}', cent_bin_min, cent_bin_max)
+    proj_detB_detC = detB_detC.ProjectionY(f'{hist_name}{detB}{detC}_proj{cent_min}_{cent_max}', cent_bin_min, cent_bin_max)
+
+    average_detA_detB = proj_detA_detB.GetMean()
+    average_detA_detC = proj_detA_detC.GetMean()
+    average_detB_detC = proj_detB_detC.GetMean()
+
+    reso = np.sqrt((average_detA_detB * average_detA_detC) / average_detB_detC) if average_detB_detC > 0 else 1.e+100000
+    return reso
+
+def check_anres(config, an_res_file, outputdir, suffix, do_ep):
+    with open(config, 'r') as ymlCfgFile:
+        config = yaml.load(ymlCfgFile, yaml.FullLoader)
+
+    pt_mins = config['ptmins']
+    pt_maxs = config['ptmaxs']
+    cent_bins = config['centrality_bins']
+    det_A = config['detA']
+    det_B = config['detB']
+    det_C = config['detC']
+    axis_cent = config['axes']['cent']
+    axis_pt = config['axes']['pt']
+    axis_mass = config['axes']['mass']
+    axis_sp = config['axes']['sp']
+    axis_deltaphi = config['axes']['deltaphi']
+    meson = config['Dmeson']
+    #axis_bdt_bkg = config['axes']['bdt_bkg']
+    #axis_bdt_sig = config['axes']['bdt_sig']
+
+    # TODO: move this to the config file
+    if meson == 'Dplus':
+        inv_mass_bins = [1.74, 1.78, 1.82, 1.84, 1.85, 1.86, 1.87, 1.88, 1.89, 1.90, 1.92, 1.96, 2.00]
+        #[1.74, 1.75, 1.76, 1.77, 1.78, 1.79, 1.80, 1.81, 1.82, 1.83, 1.835, 1.84, 1.845, 1.85, 1.855, 1.86, 1.865, 1.87, 1.875, 1.88, 1.885, 1.89, 1.895, 1.90, 1.905, 1.91, 1.915, 1.92, 1.93, 1.94, 1.95, 1.96, 1.97, 1.98, 1.99, 2.00]
+    elif meson == 'Ds':
+        inv_mass_bins = [1.8, 1.82, 1.84, 1.86, 1.88, 1.90, 1.92, 1.94, 1.96, 1.98, 2.00, 2.02, 2.04, 2.06, 2.08, 2.10]
+        
+    infile = ROOT.TFile(an_res_file, 'READ')
+    thnsparse = infile.Get('hf-task-flow-charm-hadrons/hSparseFlowCharm')
+
+    outfile = ROOT.TFile(f'{outputdir}/proj{suffix}.root', 'RECREATE')
+    hist_reso = ROOT.TH1F('hist_reso', 'hist_reso', len(cent_bins) - 1, cent_bins[0], cent_bins[-1])
+    for _, (cent_min, cent_max) in enumerate(zip(cent_bins[:-1], cent_bins[1:])):
+        thnsparse_selcent = thnsparse.Clone(f'thnsparse_selcent{cent_min}_{cent_max}')
+        thnsparse_selcent.GetAxis(axis_cent).SetRangeUser(cent_min, cent_max)
+        reso = compute_r2(infile, cent_min, cent_max, det_A, det_B, det_C, do_ep)
+        hist_reso.SetBinContent(hist_reso.FindBin(cent_min), reso)
+
+        with alive_bar(len(pt_mins)) as bar:
+            for _, (pt_min, pt_max) in enumerate(zip(pt_mins, pt_maxs)):
+                print(f'Processing pt bin {pt_min} - {pt_max}')
+                #if meson == 'Dplus':
+                    #if pt_min >= 4:
+                inv_mass_bins = [1.74, 1.78, 1.82, 1.84, 1.85, 1.86, 1.87, 1.88, 1.89, 1.90, 1.92, 1.96, 2.00]
+                    #else:
+                    #inv_mass_bins = [1.74, 1.77, 1.80, 1.81, 1.82, 1.83, 1.835, 1.84, 1.845, 1.85, 1.855, 1.86, 1.865, 1.87, 1.875, 1.88, 1.885, 1.89, 1.895, 1.90, 1.905, 1.91, 1.915, 1.92, 1.93, 1.96, 1.99, 2.00]
+                outfile.mkdir(f'cent_bins{cent_min}_{cent_max}/pt_bins{pt_min}_{pt_max}')
+                thnsparse_selcent.GetAxis(axis_pt).SetRangeUser(pt_min, pt_max)
+                
+                if do_ep:
+                    hist_vn_ep = get_vn_versus_mass(thnsparse_selcent, inv_mass_bins,
+                                                    axis_mass, axis_deltaphi, False)
+                    hist_vn_ep.SetName(f'hist_vn_ep_pt{pt_min}_{pt_max}')
+                    hist_vn_ep.SetDirectory(0)
+                    hist_vn_ep.Scale(1./reso)
+                    outfile.cd(f'cent_bins{cent_min}_{cent_max}/pt_bins{pt_min}_{pt_max}')
+                    hist_vn_ep.Write()
+                else:
+                    hist_vn_sp = get_vn_versus_mass(thnsparse_selcent, inv_mass_bins, axis_mass, axis_sp)
+                    hist_vn_sp.SetDirectory(0)
+                    hist_vn_sp.SetName(f'hist_vn_sp_pt{pt_min}_{pt_max}')
+                    hist_vn_sp.Scale(1./reso)
+                    outfile.cd(f'cent_bins{cent_min}_{cent_max}/pt_bins{pt_min}_{pt_max}')
+                    hist_vn_sp.Write()
+                hist_mass = thnsparse_selcent.Projection(axis_mass)
+                hist_mass.SetName(f'hist_mass_cent{cent_min}_{cent_max}_pt{pt_min}_{pt_max}')
+                hist_mass.Write()
+                bar()
+                outfile.cd('..')
+    outfile.cd()
+    hist_reso.Write()
+    outfile.Close()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Arguments")
+    parser.add_argument("config", metavar="text",
+                        default="config.yaml", help="configuration file")
+    parser.add_argument("an_res_file", metavar="text",
+                        default="an_res.root", help="input ROOT file with anres")
+    parser.add_argument("--outputdir", "-o", metavar="text",
+                        default=".", help="output directory")
+    parser.add_argument("--suffix", "-s", metavar="text",
+                        default="", help="suffix for output files")
+    parser.add_argument("--doEP",  action="store_true", default=False,
+                        help="do EP resolution")
+    args = parser.parse_args()
+
+    check_anres(
+        config=args.config,
+        an_res_file=args.an_res_file,
+        outputdir=args.outputdir,
+        suffix=args.suffix,
+        do_ep=args.doEP
+    )

--- a/run3/flow/run_full_flow_analysis.py
+++ b/run3/flow/run_full_flow_analysis.py
@@ -1,0 +1,108 @@
+"""
+Script to run full analysis for D resonances
+"""
+
+import argparse
+import os
+
+def run_full_analysis(config,
+                      an_res_file,
+                      centrality,
+                      suffix,
+                      doEP,
+                      skip_resolution,
+                      skip_projection,
+                      skip_rawyield
+                      ):
+    """
+    function for full analysis
+
+    Parameters
+    ----------
+
+    - config (str): path of directory with config files
+    - an_res_file (str): path of directory with analysis results
+    - centrality (str): centrality class
+    - suffix (str): suffix for output files
+    - doEP (bool): do EP resolution
+    - skip_resolution (bool): skip resolution extraction
+    - skip_projection (bool): skip projection extraction
+    - skip_rawyield (bool): skip raw yield extraction
+    """
+
+    # get all parameters needed
+    if suffix != "":
+        suffix_withopt = f" -s {suffix}"
+    else:
+        suffix = an_res_file.split("AnalysisResults")[-1].replace(".root", "")
+        suffix_withopt = f" -s {suffix}"
+    if doEP:
+        outputdir = "~/flowD/ep"
+    else:
+        outputdir = "~/flowD/sp"
+
+
+    if not skip_resolution:
+        # resolution extraction
+        outputdir_reso = f"-o {outputdir}/resolution/"
+        command_reso = f"python3 compute_reso.py {an_res_file} {suffix_withopt} {outputdir_reso}"
+        if doEP:
+            command_reso += " --doEP"
+        print("\n\033[92m Starting resolution extraction\033[0m")
+        print(f"\033[92m {command_reso}\033[0m")
+        os.system(command_reso)
+
+    if not skip_projection:
+        # projection
+        outputdir_proj = f"-o {outputdir}/proj"
+        command_proj = f"python3 project_thnsparse.py {config} {an_res_file} {suffix_withopt} {outputdir_proj}"
+        if doEP:
+            command_proj += " --doEP"
+        print("\n\033[92m Starting projection\033[0m")
+        print(f"\033[92m {command_proj}\033[0m")
+        os.system(command_proj)
+
+    if not skip_rawyield:
+        # raw yield
+        outputdir_rawyield = f"-o {outputdir}/ry"
+        proj_file = f"{outputdir}/proj/"
+        if doEP:
+            proj_file += f"proj{suffix}.root"
+            command_sim_fit = f"python3 get_vn_vs_mass.py {config} {centrality} {proj_file} {outputdir_rawyield} {suffix_withopt} --doEP"
+        else:
+            proj_file += f"proj{suffix}.root"
+            command_sim_fit = f"python3 get_vn_vs_mass.py {config} {centrality} {proj_file} {outputdir_rawyield} {suffix_withopt}"
+        print("\n\033[92m Starting simultaneous fit\033[0m")
+        print(f"\033[92m {command_sim_fit}\033[0m")
+        os.system(command_sim_fit)
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Arguments")
+    parser.add_argument("config", metavar="text",
+                        default="config.yaml", help="configuration file")
+    parser.add_argument("an_res_file", metavar="text",
+                        default="an_res.root", help="input ROOT file with anres")
+    parser.add_argument("--centrality", "-c", metavar="text",
+                        default="k3050", help="centrality class")
+    parser.add_argument("--suffix", "-s", metavar="text",
+                        default="", help="suffix for output files")
+    parser.add_argument("--doEP", action="store_true", default=False,
+                        help="do EP resolution")
+    parser.add_argument("--skip_resolution", action="store_true", default=False,
+                        help="skip resolution extraction")
+    parser.add_argument("--skip_projection", action="store_true", default=False,
+                        help="skip projection extraction")
+    parser.add_argument("--skip_rawyield", action="store_true", default=False,
+                        help="skip raw yield extraction")
+    args = parser.parse_args()
+
+    run_full_analysis(
+        args.config,
+        args.an_res_file,
+        args.centrality,
+        args.suffix,
+        args.doEP,
+        args.skip_resolution,
+        args.skip_projection,
+        args.skip_rawyield
+    )

--- a/utils/StyleFormatter.py
+++ b/utils/StyleFormatter.py
@@ -90,9 +90,9 @@ def SetGlobalStyle(**kwargs):
     if 'labelsizex' in kwargs:
         gStyle.SetLabelSize(kwargs['labelsizex'], 'x')
     if 'labelsizey' in kwargs:
-        gStyle.SetLabelSize(kwargs['labelsizex'], 'y')
+        gStyle.SetLabelSize(kwargs['labelsizey'], 'y')
     if 'labelsizez' in kwargs:
-        gStyle.SetLabelSize(kwargs['labelsizex'], 'z')
+        gStyle.SetLabelSize(kwargs['labelsizez'], 'z')
 
     # title offsets
     if 'titleoffset' in kwargs:


### PR DESCRIPTION
This PR contains the first version of the code to perform D-meson flow analysis in Run 3.

- `compute_reso.py`: compute SP/EP resolution term
- `project_thnsparse.py`: project ThnSparse as a function of pT/centrality from AnalysisResults.root
- `get_vn_vs_mass.py`: simultaneous fit to the projected inv. mass and EP/SP
- `cut_variation.py`: perform cut variation on BDT axes

The full analysis chain can be run with ``run_full_flow_analysis.py``.
The python scripts necessitate a configuration file like ``config_flow.yml``.