### PR TITLE
Add wagon_id option in flow analyses

### DIFF
--- a/run3/flow/compute_reso.py
+++ b/run3/flow/compute_reso.py
@@ -38,17 +38,19 @@ def LatLabel(label, x, y, size):
     latex.SetTextSize(size)
     latex.DrawLatex(x, y, label)
 
-def compute_reso(an_res_file, doEP, outputdir, suffix):
+def compute_reso(an_res_file, wagon_id, doEP, outputdir, suffix):
 
     detA = ['FT0c', 'FT0c', 'FT0c', 'FT0c']
     detB = ['FT0a', 'FT0a', 'FT0a', 'TPCpos']
     detC = ['FV0a', 'TPCpos', 'TPCneg', 'TPCneg']
+    print(f'Wagon ID: {wagon_id}')
 
     outfile_name = f'{outputdir}resoSP{suffix}.root' if not doEP else f'{outputdir}resoEP{suffix}.root'
     outfile = ROOT.TFile(outfile_name, 'RECREATE')
     for i, (det_a, det_b, det_c) in enumerate(zip(detA, detB, detC)):
         hist_reso, histos_det,\
         histo_means = get_resolution(an_res_file,
+                                     wagon_id,
                                      [det_a, det_b, det_c],
                                      0,
                                      100,
@@ -101,7 +103,7 @@ def compute_reso(an_res_file, doEP, outputdir, suffix):
         hist_reso.Write()
         outfile.cd('..')
 
-    input(f'Press enter to continue')
+    input('Press enter to continue')
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Arguments")
@@ -109,6 +111,8 @@ if __name__ == "__main__":
                         default="an_res.root", help="input ROOT file with anres")
     parser.add_argument("--doEP",  action="store_true", default=False,
                         help="do EP resolution")
+    parser.add_argument("--wagon_id", "-w", metavar="text",
+                        default="", help="wagon ID", required=False)
     parser.add_argument("--outputdir", "-o", metavar="text",
                         default=".", help="output directory")
     parser.add_argument("--suffix", "-s", metavar="text",
@@ -118,6 +122,7 @@ if __name__ == "__main__":
     compute_reso(
         an_res_file=args.an_res_file,
         doEP=args.doEP,
+        wagon_id=args.wagon_id,
         outputdir=args.outputdir,
         suffix=args.suffix
         )

--- a/run3/flow/flow_analysis_utils.py
+++ b/run3/flow/flow_analysis_utils.py
@@ -50,13 +50,15 @@ def get_vn_versus_mass(thnSparse, inv_mass_bins, mass_axis, vn_axis, debug=False
     
     return hist_mass_proj
 
-def get_resolution(resolution_file_name, dets, centMin, centMax, doEP=False):
+def get_resolution(resolution_file_name, wagon_id, dets, centMin, centMax, doEP=False):
     '''
     Compute resolution for SP or EP method
 
     Input:
         - resolution_file_name: 
             str, path to the resolution file
+        - wagon_id:
+            str, wagon ID
         - dets: 
             list of strings, subsystems to compute the resolution
             if 2 subsystems are given, the resolution is computed as the product of the two
@@ -86,11 +88,13 @@ def get_resolution(resolution_file_name, dets, centMin, centMax, doEP=False):
     dets = [f'{detA}{detB}', f'{detA}{detC}', f'{detB}{detC}'] if len(dets) == 3 else [f'{detA}{detB}']
     
     # set path and prefix
+    if wagon_id != '':
+        wagon_id = f'_id{wagon_id}'
     if doEP:
-        path = 'hf-task-flow-charm-hadrons/epReso/'
+        path = f'hf-task-flow-charm-hadrons{wagon_id}/epReso/'
         prefix = 'EpReso'
     else:
-        path = 'hf-task-flow-charm-hadrons/spReso/'
+        path = f'hf-task-flow-charm-hadrons{wagon_id}/spReso/'
         prefix = 'SpReso'
    
     # collect the qvecs and the prepare histo for mean and resolution
@@ -186,13 +190,15 @@ def get_centrality_bins(centrality):
         print(f"ERROR: cent class \'{centrality}\' is not supported! Exit")
     sys.exit()
 
-def compute_r2(reso_file, cent_min, cent_max, detA, detB, detC, do_ep):
+def compute_r2(reso_file, wagon_id, cent_min, cent_max, detA, detB, detC, do_ep):
     '''
     Compute resolution for SP or EP method
     
     Input:
         - reso_file:
             TFile, resolution file
+        - wagon_id:
+            str, wagon ID
         - cent_min:
             int, minimum centrality bin
         - cent_max:
@@ -211,10 +217,12 @@ def compute_r2(reso_file, cent_min, cent_max, detA, detB, detC, do_ep):
         - reso:
             float, resolution value
     '''
+    if wagon_id != '':
+        wagon_id = f'_id{wagon_id}'
     if do_ep:
-        hist_name = 'hf-task-flow-charm-hadrons/epReso/hEpReso'
+        hist_name = f'hf-task-flow-charm-hadrons{wagon_id}/epReso/hEpReso'
     else:
-        hist_name = 'hf-task-flow-charm-hadrons/spReso/hSpReso'
+        hist_name = f'hf-task-flow-charm-hadrons{wagon_id}/spReso/hSpReso'
 
     detA_detB = reso_file.Get(f'{hist_name}{detA}{detB}')
     detA_detC = reso_file.Get(f'{hist_name}{detA}{detC}')
@@ -223,9 +231,12 @@ def compute_r2(reso_file, cent_min, cent_max, detA, detB, detC, do_ep):
     cent_bin_min = detA_detB.GetXaxis().FindBin(cent_min)
     cent_bin_max = detA_detB.GetXaxis().FindBin(cent_max)
 
-    proj_detA_detB = detA_detB.ProjectionY(f'{hist_name}{detA}{detB}_proj{cent_min}_{cent_max}', cent_bin_min, cent_bin_max)
-    proj_detA_detC = detA_detC.ProjectionY(f'{hist_name}{detA}{detC}_proj{cent_min}_{cent_max}', cent_bin_min, cent_bin_max)
-    proj_detB_detC = detB_detC.ProjectionY(f'{hist_name}{detB}{detC}_proj{cent_min}_{cent_max}', cent_bin_min, cent_bin_max)
+    proj_detA_detB = detA_detB.ProjectionY(f'{hist_name}{detA}{detB}_proj{cent_min}_{cent_max}',
+                                           cent_bin_min, cent_bin_max)
+    proj_detA_detC = detA_detC.ProjectionY(f'{hist_name}{detA}{detC}_proj{cent_min}_{cent_max}',
+                                           cent_bin_min, cent_bin_max)
+    proj_detB_detC = detB_detC.ProjectionY(f'{hist_name}{detB}{detC}_proj{cent_min}_{cent_max}',
+                                           cent_bin_min, cent_bin_max)
 
     average_detA_detB = proj_detA_detB.GetMean()
     average_detA_detC = proj_detA_detC.GetMean()

--- a/run3/flow/run_full_flow_analysis.py
+++ b/run3/flow/run_full_flow_analysis.py
@@ -11,6 +11,7 @@ def run_full_analysis(config,
                       outputdir,
                       suffix,
                       doEP,
+                      wagon_id,
                       skip_resolution,
                       skip_projection,
                       skip_rawyield
@@ -27,6 +28,7 @@ def run_full_analysis(config,
     - outputdir (str): output directory
     - suffix (str): suffix for output files
     - doEP (bool): do EP resolution
+    - wagon_id (str): wagon ID
     - skip_resolution (bool): skip resolution extraction
     - skip_projection (bool): skip projection extraction
     - skip_rawyield (bool): skip raw yield extraction
@@ -43,6 +45,7 @@ def run_full_analysis(config,
     else:
         outputdir = f"{outputdir}/sp"
     cent_withopt = f" -c {centrality}"
+    wagon_id_withopt = f" -w {wagon_id}"
 
     if skip_resolution and skip_projection and skip_rawyield:
         print("\033[91m Nothing to do, all steps are skipped\033[0m")
@@ -58,6 +61,8 @@ def run_full_analysis(config,
             os.makedirs(f"{outputdir}/resolution")
         outputdir_reso = f"-o {outputdir}/resolution/"
         command_reso = f"python3 compute_reso.py {an_res_file} {suffix_withopt} {outputdir_reso}"
+        if wagon_id != "":
+            command_reso += f" {wagon_id_withopt}"
         if doEP:
             command_reso += " --doEP"
         print("\n\033[92m Starting resolution extraction\033[0m")
@@ -70,6 +75,8 @@ def run_full_analysis(config,
             os.makedirs(f"{outputdir}/proj")
         outputdir_proj = f"-o {outputdir}/proj"
         command_proj = f"python3 project_thnsparse.py {config} {an_res_file} {cent_withopt} {suffix_withopt} {outputdir_proj}"
+        if wagon_id != "":
+            command_proj += f" {wagon_id_withopt}"
         if doEP:
             command_proj += " --doEP"
         print("\n\033[92m Starting projection\033[0m")
@@ -106,6 +113,8 @@ if __name__ == "__main__":
                         default="", help="suffix for output files")
     parser.add_argument("--doEP", action="store_true", default=False,
                         help="do EP resolution")
+    parser.add_argument("--wagon_id", "-w", metavar="text",
+                        default="", help="wagon ID", required=False)
     parser.add_argument("--skip_resolution", action="store_true", default=False,
                         help="skip resolution extraction")
     parser.add_argument("--skip_projection", action="store_true", default=False,
@@ -121,6 +130,7 @@ if __name__ == "__main__":
         args.outputdir,
         args.suffix,
         args.doEP,
+        args.wagon_id,
         args.skip_resolution,
         args.skip_projection,
         args.skip_rawyield


### PR DESCRIPTION
This PR adds the possibility of handling multiple wagon outputs contained in the same AO2D from the flow analysis task in O2Physics 