### PR TITLE
Improvements for kde fitting

### DIFF
--- a/run3/flow/config_flow.yml
+++ b/run3/flow/config_flow.yml
@@ -62,6 +62,25 @@ FixSigmaRatio: 0 # used only if SgnFunc = k2GausSigmaRatioPar
 SigmaRatioFile: ""
 BoundMean: 0 # 0: Do not set limits on mean range, 1: the mean is set to be between MassMin[i] and MassMax[i]
 
+### config to use pre-processed AnalysisResults files 
+skim_out_dir: '/Users/mcosti/Analysis/Datasets/3050/skim3040bkgstrict'
+
+DrawVnComps: true  # draw single terms of vn function
+IncludeKDETempls: [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]  # boolean flag to include templates or not
+FromGrid: true # compute templates from TemplsInputs, else take them from file with FromFile flag
+# To add more templates, use [part1, ... ,partN]
+TemplsFlags: [2]  # flag of flagMcDecayRec to query the dataframe from which the KDE is obtained
+TemplsInputs: ['/Users/mcosti/Analysis/Datasets/Templates/AO2D_325626.root']  # input AODs for templates
+TemplsTreeNames: ['O2hfcanddplite'] # name of tree in the AO2D file
+### init weights for mass templates and vn of templates
+InitWeights: [[500], [500], [500], [500], [500], [500], [500], [500], [500], [500], [500], [500], [500], [500], [500]]
+MinWeights: [[0], [0], [0], [0], [0], [0], [0], [0], [0], [0], [0], [0], [0], [0], [0], [0],]
+MaxWeights: [[1000], [1000], [1000], [1000], [1000], [1000], [1000], [1000], [1000], [1000], [1000], [1000], [1000], [1000], [1000]]
+FixVnTemplToSgn: [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]
+VnInitWeights: [[0.1], [0.1], [0.1], [0.1], [0.1], [0.1], [0.1], [0.1], [0.1], [0.1], [0.1], [0.1], [0.1], [0.1], [0.1]]
+VnMinWeights: [[0], [0], [0], [0], [0], [0], [0], [0], [0], [0], [0], [0], [0], [0], [0]]
+VnMaxWeights: [[0.2], [0.2], [0.2], [0.2], [0.2], [0.2], [0.2], [0.2], [0.2], [0.2], [0.2], [0.2], [0.2], [0.2], [0.2]]
+
 # efficiency
 eff_filename: 'task_output.root'
 

--- a/run3/flow/config_flow.yml
+++ b/run3/flow/config_flow.yml
@@ -80,6 +80,7 @@ FixVnTemplToSgn: [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]
 VnInitWeights: [[0.1], [0.1], [0.1], [0.1], [0.1], [0.1], [0.1], [0.1], [0.1], [0.1], [0.1], [0.1], [0.1], [0.1], [0.1]]
 VnMinWeights: [[0], [0], [0], [0], [0], [0], [0], [0], [0], [0], [0], [0], [0], [0], [0]]
 VnMaxWeights: [[0.2], [0.2], [0.2], [0.2], [0.2], [0.2], [0.2], [0.2], [0.2], [0.2], [0.2], [0.2], [0.2], [0.2], [0.2]]
+InitBkg: [ [[initval_par0_ptbin0, lowlim_par0_ptbin0, upplim_par0_ptbin0], [initval_par1_ptbin0, lowlim_par1_ptbin0, upplim_par1_ptbin0]],[empty if no initialization],[],[],[],[],[],[],[],[],[],[],[],[],[]]
 
 # efficiency
 eff_filename: 'task_output.root'

--- a/run3/flow/flow_analysis_utils.py
+++ b/run3/flow/flow_analysis_utils.py
@@ -774,7 +774,7 @@ def get_particle_info(particleName):
 
     return particleTit, massAxisTit, decay, massForFit
 
-def get_cut_sets(npt_bins, sig_cut, bkg_cut_maxs, correlated_cuts=True):
+def get_cut_sets(pt_mins, pt_maxs, sig_cut, bkg_cut_maxs, correlated_cuts=True):
     '''
     Get cut sets
 
@@ -803,7 +803,6 @@ def get_cut_sets(npt_bins, sig_cut, bkg_cut_maxs, correlated_cuts=True):
             list of lists of floats, list of upper edge for background cuts
     '''
     nCutSets = []
-    print(f"Number of pt bins: {npt_bins}")
     sig_cuts_lower, sig_cuts_upper, bkg_cuts_lower, bkg_cuts_upper = {}, {}, {}, {}
     if correlated_cuts:
         sig_cut_mins = sig_cut['min']
@@ -811,31 +810,31 @@ def get_cut_sets(npt_bins, sig_cut, bkg_cut_maxs, correlated_cuts=True):
         sig_cut_steps = sig_cut['step']
 
         # compute the signal cutsets for each pt bin
-        sig_cuts_lower = [list(np.arange(sig_cut_mins[iPt], sig_cut_maxs[iPt], sig_cut_steps[iPt])) for iPt in range(npt_bins)]
-        sig_cuts_upper = [[1.0 for _ in range(len(sig_cuts_lower[iPt]))] for iPt in range(npt_bins)]
+        sig_cuts_lower = [list(np.arange(sig_cut_mins[iPt], sig_cut_maxs[iPt], sig_cut_steps[iPt])) for iPt in range(len(pt_mins))]
+        sig_cuts_upper = [[1.0 for _ in range(len(sig_cuts_lower[iPt]))] for iPt in range(len(pt_mins))]
 
         # compute the ncutsets by signal cut for each pt bin
-        nCutSets = [len(sig_cuts_lower[iPt]) for iPt in range(npt_bins)]
+        nCutSets = [len(sig_cuts_lower[iPt]) for iPt in range(len(pt_mins))]
 
         # bkg cuts lower edge should always be 0
-        bkg_cuts_lower = [[0. for _ in range(nCutSets[iPt])] for iPt in range(npt_bins)]
-        bkg_cuts_upper = [[bkg_cut_maxs[iPt] for _ in range(nCutSets[iPt])] for iPt in range(npt_bins)]
+        bkg_cuts_lower = [[0. for _ in range(nCutSets[iPt])] for iPt in range(len(pt_mins))]
+        bkg_cuts_upper = [[bkg_cut_maxs[iPt] for _ in range(nCutSets[iPt])] for iPt in range(len(pt_mins))]
 
     else:
         # load the signal cut
-        sig_cuts_lower = [sig_cut[iPt]['min'] for iPt in range(npt_bins)]
-        sig_cuts_upper = [sig_cut[iPt]['max'] for iPt in range(npt_bins)]
+        sig_cuts_lower = [sig_cut[iPt]['min'] for iPt in range(len(pt_mins))]
+        sig_cuts_upper = [sig_cut[iPt]['max'] for iPt in range(len(pt_mins))]
         
         # compute the ncutsets by the signal cut for each pt bin
-        nCutSets = [len(sig_cuts_lower[iPt]) for iPt in range(npt_bins)]
+        nCutSets = [len(sig_cuts_lower[iPt]) for iPt in range(len(pt_mins))]
         
         # load the background cut
-        bkg_cuts_lower = [[0. for _ in range(nCutSets[iPt])] for iPt in range(npt_bins)]
-        bkg_cuts_upper = [[bkg_cut_maxs[iPt] for _ in range(nCutSets[iPt])] for iPt in range(npt_bins)]
+        bkg_cuts_lower = [[0. for _ in range(nCutSets[iPt])] for iPt in range(len(pt_mins))]
+        bkg_cuts_upper = [[bkg_cut_maxs[iPt] for _ in range(nCutSets[iPt])] for iPt in range(len(pt_mins))]
         
     # safety check
 
-    for iPt in range(npt_bins):
+    for iPt in range(len(pt_mins)):
         assert len(sig_cuts_lower[iPt]) == len(sig_cuts_upper[iPt]) == len(bkg_cuts_lower[iPt]) == len(bkg_cuts_upper[iPt]) == nCutSets[iPt], \
             f"Mismatch in lengths for pt bin {iPt}: {len(sig_cuts_lower[iPt])}, {len(sig_cuts_upper[iPt])}, \
             {len(bkg_cuts_lower[iPt])}, {len(bkg_cuts_upper[iPt])}, \
@@ -874,4 +873,4 @@ def get_cut_sets_config(config):
         sig_cut = config['cut_variation']['uncorr_bdt_cut']['sig']
         bkg_cut_maxs = config['cut_variation']['uncorr_bdt_cut']['bkg_max']
 
-    return get_cut_sets(len(ptmins), sig_cut, bkg_cut_maxs, correlated_cuts)
+    return get_cut_sets(ptmins, ptmaxs, sig_cut, bkg_cut_maxs, correlated_cuts)

--- a/run3/flow/get_vn_vs_mass.py
+++ b/run3/flow/get_vn_vs_mass.py
@@ -9,8 +9,10 @@ import argparse
 import ctypes
 import numpy as np
 import yaml
+import os
+import itertools
 from ROOT import TLatex, TFile, TCanvas, TLegend, TH1D, TH1F, TDatabasePDG, TGraphAsymmErrors # pylint: disable=import-error,no-name-in-module
-from ROOT import gROOT, gPad, gInterpreter, kBlack, kRed, kAzure, kGray, kOrange, kGreen, kMagenta, kFullCircle, kFullSquare, kOpenCircle # pylint: disable=import-error,no-name-in-module
+from ROOT import gROOT, gPad, gInterpreter, kBlack, kRed, kAzure, kCyan, kGray, kOrange, kGreen, kMagenta, kFullCircle, kFullSquare, kOpenCircle # pylint: disable=import-error,no-name-in-module
 from flow_analysis_utils import get_centrality_bins, get_vnfitter_results, get_ep_vn, getD0ReflHistos, get_particle_info # pylint: disable=import-error,no-name-in-module
 sys.path.append('../../..')
 sys.path.append('../..')
@@ -56,8 +58,9 @@ def get_vn_vs_mass(fitConfigFileName, centClass, inFileName,
     massMaxs = fitConfig['MassMax']
     if not isinstance(massMaxs, list):
         massMaxs = [massMaxs] * len(ptMins)
-    useRefl = fitConfig['enableRef']
-    reflFile = fitConfig['ReflFile']
+    useRefl = fitConfig.get('InclRefl')
+    reflFile = fitConfig.get('ReflFile', None)
+    useTemplates = fitConfig.get('IncludeKDETempls')
 
     # read fit configuration
     if not isinstance(fixSigma, list):
@@ -88,9 +91,6 @@ def get_vn_vs_mass(fitConfigFileName, centClass, inFileName,
         elif bkgStr == 'kPol3':
             BkgFunc.append(6)
             degPol[-1] = 3
-            if len(ptMins) > 1 and inclSecPeak[iPt] == 1:
-                print('ERROR: Pol3 and Pol4 fits work only with one bin if you have the secondary peak! Exit!')
-                sys.exit()
         elif bkgStr == 'kPol4':
             BkgFunc.append(6)
             degPol[-1] = 4
@@ -124,27 +124,48 @@ def get_vn_vs_mass(fitConfigFileName, centClass, inFileName,
             sys.exit()
 
     KDEtemplatesFuncts = []
-    if fitConfig.get('IncludeKDETempls'):
-        KDEtemplates = [[None]*len(fitConfig['TemplsFlags']) for _ in range(len(ptMins))]
+    KDEtemplates = [[None]*len(fitConfig['TemplsFlags']) for _ in range(len(ptMins))]
+    if useTemplates:
+        cTemplOverlap = [[None]*len(fitConfig['TemplsFlags']) for _ in range(len(ptMins))]
+        hRebinnedHistos = [[None]*len(fitConfig['TemplsFlags']) for _ in range(len(ptMins))]
+        templatesFile = TFile(f'{outputdir}/Templates.root', 'recreate')
         for iPt in range(len(ptMins)):
             for iFlag, flag in enumerate(fitConfig['TemplsFlags']):
-                if fitConfig.get('FromGrid'):
-                    KDEtemplates[iPt][iFlag] = kde_producer(fitConfig['TemplsInputs'][iFlag],
-                                                     'fM', ptMins[iPt], ptMaxs[iPt], flag, '',
-                                                     fitConfig['TemplsTreeNames'][iFlag])
-                elif fitConfig.get('FromFile'):
+                if not fitConfig['IncludeKDETempls'][iPt]:
+                    KDEtemplates[iPt][iFlag], kde_func, hRebinnedHistos[iPt][iFlag], cTemplOverlap[iPt][iFlag] = None, None, None, None
+                    continue
+                elif fitConfig['IncludeKDETempls'][iPt] and fitConfig.get('FromGrid'):
+                    KDEtemplates[iPt][iFlag], kde_func, hRebinnedHistos[iPt][iFlag] = kde_producer(fitConfig['TemplsInputs'][iFlag], 'fM', ptMins[iPt], ptMaxs[iPt], flag,
+                                                                      templatesFile, fitConfig['TemplsTreeNames'][iFlag])
+                    templatesFile.cd()
+                    hRebinnedHistos[iPt][iFlag].Write(f"hBinned_pt_{iPt}")
+                    cTemplOverlap[iPt][iFlag] = TCanvas(f'cOverlap_{iPt}_{flag}', f'cOverlap_{iPt}_{flag}', 600, 600)
+                    cTemplOverlap[iPt][iFlag].cd()
+                    hRebinnedHistos[iPt][iFlag].Draw()
+                    kde_func.Draw('same')
+                    cTemplOverlap[iPt][iFlag].Write()
+                elif fitConfig['IncludeKDETempls'][iPt] and fitConfig.get('FromFile'):
                     templFile = TFile.Open(f'{fitConfig["FromFile"]}', 'r')
-                    KDEtemplates[iPt][iFlag] = templFile.Get(f'KDE_pt_{ptMins[iPt]}_{ptMaxs[iPt]}_flag{flag}')
+                    KDEtemplates[iPt][iFlag] = templFile.Get(f'KDE_pt_{ptMins[iPt]}_{ptMaxs[iPt]}_flag{flag}/KDEFunc_')
+                    hRebinnedHistos[iPt][iFlag] = templFile.Get(f'KDE_pt_{ptMins[iPt]}_{ptMaxs[iPt]}_flag{flag}/hBinned')
                     templFile.Close()
+                    cTemplOverlap[iPt][iFlag] = TCanvas(f'cOverlap_{iPt}_{flag}', f'cOverlap_{iPt}_{flag}', 600, 600)
+                    cTemplOverlap[iPt][iFlag].cd()
+                    hRebinnedHistos[iPt][iFlag].Draw()
+                    kde_func.Draw('same')
                 else:
                     print(f'ERROR: incorrect setting for including KDEs in fit! Exit!')
                     sys.exit()
-        KDEtemplatesFuncts = [[KDE.GetFunction() for KDE in KDEtemplatesPt] for KDEtemplatesPt in KDEtemplates]
+        templatesFile.Close()
+        KDEtemplatesFuncts = [[KDE.GetFunction() if KDE is not None else None for KDE in KDEtemplatesPt] for KDEtemplatesPt in KDEtemplates]
     
     # set particle configuration
     if particleName == 'Ds':
         _, massAxisTit, decay, massForFit = get_particle_info(particleName)
         massDplus = TDatabasePDG.Instance().GetParticle(411).Mass()
+    if particleName == 'Dplus':
+        _, massAxisTit, decay, massForFit = get_particle_info(particleName)
+        massDstar = TDatabasePDG.Instance().GetParticle(413).Mass()
     else:
         _, massAxisTit, decay, massForFit = get_particle_info(particleName)
 
@@ -156,15 +177,15 @@ def get_vn_vs_mass(fitConfigFileName, centClass, inFileName,
     hRel, hSig, hMassForRel, hMassForSig  = [], [], [], []
     hMass, hMassForFit, hVn, hVnForFit = [], [], [], []
     hMassIns, hMassOuts, hMassInsForFit, hMassOutsForFit = [], [], [], []
-    fTotFuncMass, fTotFuncVn, fSgnFuncMass, fBkgFuncMass, fMassBkgRflFunc,fBkgFuncVn = [], [], [], [], [], []
+    fTotFuncMass, fTotFuncVn, fSgnFuncMass, fBkgFuncMass, fMassBkgRflFunc, fMassSecPeakFunc, fBkgFuncVn, fVnSecPeakFunc = [], [], [], [], [], [], [], []
     hMCSgn, hMCRefl = [], []
-    fMassTemplFuncts = [[None]*len(fitConfig['TemplsFlags']) for _ in range(len(ptMins))] if fitConfig.get('IncludeKDETempls') else [] 
-    fVnTemplFuncts = [[None]*len(fitConfig['TemplsFlags']) for _ in range(len(ptMins))] if fitConfig.get('IncludeKDETempls') else []
-    hist_reso = infile.Get('hist_reso')
+    fMassTemplFuncts = [[None]*len(fitConfig['TemplsFlags']) for _ in range(len(ptMins))] if useTemplates else [] 
+    fVnCompFuncts = [[None]*len(fitConfig['TemplsFlags']) for _ in range(len(ptMins))] if fitConfig.get('DrawVnComps') else []
+    hist_reso = infile.Get('histo_reso_delta_cent')
     hist_reso.SetDirectory(0)
     reso = hist_reso.GetBinContent(1)
     inclSecPeak = [inclSecPeak] * len(ptMins) if not isinstance(inclSecPeak, list) else inclSecPeak
-    for iPt, (ptMin, ptMax, secPeak) in enumerate(zip(ptMins, ptMaxs, inclSecPeak)):
+    for iPt, (ptMin, ptMax) in enumerate(zip(ptMins, ptMaxs)):
         if not vn_method == 'sp' and not vn_method == 'ep':
             print(f'loading: cent_bins{cent}/pt_bins{ptMin}_{ptMax}/hist_mass_cent{cent}_pt{ptMin}_{ptMax}')
             hMassIns.append(infile.Get(f'cent_bins{cent}/pt_bins{ptMin}_{ptMax}/hist_mass_inplane_cent{cent}_pt{ptMin}_{ptMax}'))
@@ -301,6 +322,16 @@ def get_vn_vs_mass(fitConfigFileName, centClass, inFileName,
     gvnUnc.SetName('gvnUnc')
     gvnUncSecPeak = TGraphAsymmErrors(1)
     gvnUncSecPeak.SetName('gvnUncSecPeak')
+    gvnTempls = []
+    gvnTemplsUncs = []
+    if useTemplates:
+        for iTempl in fitConfig['TemplsFlags']:
+            gvnTempl = TGraphAsymmErrors(1)
+            gvnTempl.SetName('gvnTemplUnc')
+            gvnTempls.append(gvnTempl)
+            gvnTemplUnc = TGraphAsymmErrors(1)
+            gvnTemplUnc.SetName('gvnUncSecPeak')
+            gvnTemplsUncs.append(gvnTemplUnc)
     SetObjectStyle(gvnSimFit, color=kBlack, markerstyle=kFullCircle)
     SetObjectStyle(gvnSimFitSecPeak, color=kRed, markerstyle=kOpenCircle)
     SetObjectStyle(gvnUnc, color=kBlack, markerstyle=kFullCircle)
@@ -381,7 +412,12 @@ def get_vn_vs_mass(fitConfigFileName, centClass, inFileName,
                 print(f'NSigma4SB = {fitConfig["NSigma4SB"][iPt]}')
             # Second peak (Ds specific)
             if secPeak and particleName == 'Ds':
-                vnFitter[iPt].IncludeSecondGausPeak(massDplus, False, fitConfig['SigmaSecPeak'][iPt], False, 1)
+                vnFitter[iPt].IncludeSecondGausPeak(massDplus, False, fitConfig['SigmaSecPeak'][iPt], False, 1, fitConfig.get('FixVnSecPeakToSgn', False))
+                if fixSigma[iPt]:
+                    vnFitter[iPt].FixSigma2GausFromMassFit()
+            # Second peak (Dplus specific)
+            if secPeak and particleName == 'Dplus':
+                vnFitter[iPt].IncludeSecondGausPeak(massDstar, False, fitConfig['SigmaSecPeak'][iPt], False, 1, fitConfig.get('FixVnSecPeakToSgn', False))
                 if fixSigma[iPt]:
                     vnFitter[iPt].FixSigma2GausFromMassFit()
             vnFitter[iPt].FixFrac2GausFromMassFit()
@@ -393,22 +429,33 @@ def get_vn_vs_mass(fitConfigFileName, centClass, inFileName,
                 vnFitter[iPt].SetTemplateReflections(hMCRefl[iPt],reflFuncStr,massMin,massMax)
                 vnFitter[iPt].SetFixReflOverS(SoverR)
                 vnFitter[iPt].SetReflVnOption(0) # kSameVnSignal
-            if fitConfig.get('IncludeKDETempls'):
-                vnFitter[iPt].SetKDETemplates(KDEtemplatesFuncts[iPt], fitConfig['TemplsTreeNames'],
-                                              fitConfig['InitWeights'][iPt], fitConfig['MinWeights'][iPt], 
-                                              fitConfig['MaxWeights'][iPt])
+            if useTemplates:
+                if fitConfig['IncludeKDETempls'][iPt]:
+                    vnFitter[iPt].SetKDETemplates(KDEtemplatesFuncts[iPt], fitConfig['TemplsFlags'],
+                                                fitConfig['InitWeights'][iPt], fitConfig['MinWeights'][iPt], fitConfig['MaxWeights'][iPt], 
+                                                fitConfig['VnInitWeights'][iPt], fitConfig['VnMinWeights'][iPt], fitConfig['VnMaxWeights'][iPt], 
+                                                fitConfig['FixVnTemplToSgn'][iPt])
+
+            if fitConfig.get('InitBkg'):
+                if fitConfig['InitBkg'][iPt] != []:
+                    vnFitter[iPt].SetBkgPars(list(itertools.chain(*fitConfig['InitBkg'][iPt])))
 
             # collect fit results
             vnFitter[iPt].SimultaneousFit(False)
-            vnResults = get_vnfitter_results(vnFitter[iPt], secPeak, useRefl)
+            vnComps = vnFitter[iPt].GetVnCompsFuncts()
+            vnResults = get_vnfitter_results(vnFitter[iPt], secPeak, useRefl, fitConfig['IncludeKDETempls'][iPt])
             fTotFuncMass.append(vnResults['fTotFuncMass'])
             fTotFuncVn.append(vnResults['fTotFuncVn'])
             fSgnFuncMass.append(vnResults['fSgnFuncMass'])
             fBkgFuncMass.append(vnResults['fBkgFuncMass'])
             fBkgFuncVn.append(vnResults['fBkgFuncVn'])
-            if fitConfig.get('IncludeKDETempls'):
+            if secPeak:
+                fMassSecPeakFunc.append(vnResults['fMassSecPeakFunc'])
+                fVnSecPeakFunc.append(vnResults['fVnSecPeakFunct'])
+            if fitConfig['IncludeKDETempls'][iPt]:
                 fMassTemplFuncts[iPt] = vnResults['fMassTemplFuncts']
-                fVnTemplFuncts[iPt] = vnResults['fVnTemplFuncts']
+            if fitConfig.get('DrawVnComps'):
+                fVnCompFuncts[iPt] = vnResults['fVnCompsFuncts']
 
             if useRefl:
                 fMassBkgRflFunc.append(vnResults['fMassBkgRflFunc'])
@@ -450,6 +497,12 @@ def get_vn_vs_mass(fitConfigFileName, centClass, inFileName,
                                                vnResults['vnSecPeakUnc'])
                 gvnUncSecPeak.SetPoint(iPt, (ptMin+ptMax)/2, vnResults['vnSecPeakUnc'])
                 gvnUncSecPeak.SetPointError(iPt, (ptMax-ptMin)/2, (ptMax-ptMin)/2, 1.e-20, 1.e-20)
+            if fitConfig['IncludeKDETempls'][iPt]:
+                for iTempl, (templVn, templVnUnc) in enumerate(zip(vnResults["vnTemplates"], vnResults["vnTemplatesUncs"])):
+                    gvnTempls[iTempl].SetPoint(iPt, (ptMin+ptMax)/2, templVn)
+                    gvnTempls[iTempl].SetPointError(iPt, (ptMax-ptMin)/2, (ptMax-ptMin)/2, 1.e-20, 1.e-20)
+                    gvnTemplsUncs[iTempl].SetPoint(iPt, (ptMin+ptMax)/2, templVnUnc)
+                    gvnTemplsUncs[iTempl].SetPointError(iPt, (ptMax-ptMin)/2, (ptMax-ptMin)/2, 1.e-20, 1.e-20)
 
             if vnResults['vn'] != 0:
                 cSimFit[iPt].cd(1)
@@ -470,6 +523,9 @@ def get_vn_vs_mass(fitConfigFileName, centClass, inFileName,
                 if useRefl:
                     fMassBkgRflFunc[iPt].Draw('same')
                     hRel[iPt].Draw('same')
+                if secPeak:
+                    SetObjectStyle(fMassSecPeakFunc[-1], fillcolor=kGreen+1, fillstyle=3254, linewidth=0)
+                    fMassSecPeakFunc[-1].Draw('same')
                 latex.DrawLatex(0.18, 0.80, f'#mu = {vnResults["mean"]:.3f} #pm {vnResults["meanUnc"]:.3f} GeV/c^{2}')
                 latex.DrawLatex(0.18, 0.75, f'#sigma = {vnResults["sigma"]:.3f} #pm {vnResults["sigmaUnc"]:.3f} GeV/c^{2}')
                 latex.DrawLatex(0.18, 0.70, f'S = {vnResults["ry"]:.0f} #pm {vnResults["ryUnc"]:.0f}')
@@ -477,15 +533,19 @@ def get_vn_vs_mass(fitConfigFileName, centClass, inFileName,
                 latex.DrawLatex(0.18, 0.60, f'Signif. (3#sigma) = {round(vnResults["signif"], 2)}')
                 if useRefl:
                     latex.DrawLatex(0.18, 0.20, f'RoverS = {SoverR:.2f}')
-                if fitConfig.get('IncludeKDETempls'):
+                if fitConfig['IncludeKDETempls'][iPt]:
                     for iMassTemplFunct, massTemplFunct in enumerate(fMassTemplFuncts[iPt]):
-                        SetObjectStyle(massTemplFunct, color=kMagenta+iMassTemplFunct*2, linewidth=3)
-                        massTemplFunct.SetLineColor(1)
+                        SetObjectStyle(massTemplFunct, color=kMagenta+2+iMassTemplFunct*2, linewidth=3)
                         massTemplFunct.Draw('same')
                         cSimFit[iCanv].Modified()
                         cSimFit[iCanv].Update()
                 cSimFit[iPt].cd(2)
-                hVnForFit[iPt].GetYaxis().SetRangeUser(-0.2, 0.4)
+                if fitConfig.get('DrawVnComps'):
+                    hVnForFit[iPt].GetYaxis().SetRangeUser(-0.2, 0.4)
+                else:
+                    minCounts = hVnForFit[iPt].GetMinimum()
+                    maxCounts = hVnForFit[iPt].GetMaximum()
+                    hVnForFit[iPt].GetYaxis().SetRangeUser(minCounts-(0.2*minCounts), maxCounts+(0.2*maxCounts))
                 hVnForFit[iPt].GetYaxis().SetTitle(f'#it{{v}}_{{{harmonic}}} ({vn_method})')
                 hVnForFit[iPt].GetXaxis().SetRangeUser(massMin, massMax)
                 hVnForFit[iPt].Draw('E')
@@ -497,16 +557,31 @@ def get_vn_vs_mass(fitConfigFileName, centClass, inFileName,
                 latex.DrawLatex(0.18, 0.18, f'#chi^{{2}}/ndf = {vnResults["chi2"]:.2f}')
                 latex.DrawLatex(0.18, 0.80,
                                 f'#it{{v}}{harmonic}({particleName}) = {vnResults["vn"]:.3f} #pm {vnResults["vnUnc"]:.3f}')
-                if secPeak:
+                if secPeak and particleName == "Ds":
                     latex.DrawLatex(0.18, 0.75,
                                     f'#it{{v}}{harmonic}(D^{{+}}) = {vnResults["vnSecPeak"]:.3f} #pm {vnResults["vnSecPeakUnc"]:.3f}')
-                if fitConfig.get('IncludeKDETempls'):
-                    if fitConfig.get('drawvncomps'):
-                        for iVnTemplFunct, vnTemplFunct in enumerate(fVnTemplFuncts[iPt]):
-                            vnTemplFunct.SetLineColor(iVnTemplFunct+1)
-                            vnTemplFunct.Draw('same')
-                            cSimFit[iCanv].Modified()
-                            cSimFit[iCanv].Update()
+                if secPeak and particleName == "Dplus":
+                    latex.DrawLatex(0.18, 0.75,
+                                    f'#it{{v}}{harmonic}(D^{{*}}) = {vnResults["vnSecPeak"]:.3f} #pm {vnResults["vnSecPeakUnc"]:.3f}')
+                if fitConfig['IncludeKDETempls'][iPt]:
+                    for iVnTempl, (vnCoeff, vnCoeffUnc) in enumerate(zip(vnResults["vnTemplates"], vnResults["vnTemplatesUncs"])):
+                        latex.DrawLatex(0.18, 0.70-iVnTempl*0.05,
+                                    f'#it{{v}}{harmonic}(Templ{iVnTempl}) = {vnCoeff:.3f} #pm {vnCoeffUnc:.3f}')
+                        cSimFit[iCanv].Modified()
+                        cSimFit[iCanv].Update()
+                if fitConfig.get('DrawVnComps'):
+                    SetObjectStyle(fVnCompFuncts[iPt]['vnSgn'], fillcolor=kAzure+4, fillstyle=3245, linewidth=0)
+                    SetObjectStyle(fVnCompFuncts[iPt]['vnBkg'], color=kOrange+1, linestyle=1, linewidth=2)
+                    if secPeak:
+                        SetObjectStyle(fVnCompFuncts[iPt]['vnSecPeak'], fillcolor=kGreen+1, fillstyle=3254, linewidth=0)
+                    if fitConfig['IncludeKDETempls'][iPt]:
+                        for iTempl in range(len(fVnCompFuncts[iPt])-2-secPeak):
+                            SetObjectStyle(fVnCompFuncts[iPt][f'vnTempl{iTempl}'], color=kMagenta+2+iTempl*2, linewidth=3)
+                    for vnCompKey, vnCompFunct in fVnCompFuncts[iPt].items():
+                        vnCompFunct.Draw('same')
+                        cSimFit[iCanv].Modified()
+                        cSimFit[iCanv].Update()
+
                 cSimFit[iCanv].Modified()
                 cSimFit[iCanv].Update()
 
@@ -593,8 +668,8 @@ def get_vn_vs_mass(fitConfigFileName, centClass, inFileName,
                         massFitterOuts[iPt].SetInitialGaussianSigma(0.008)
 
             if secPeak and particleName == 'Ds':
-                massFitterIns[iPt].IncludeSecondGausPeak(massDplus, False, fitConfig['SigmaSecPeak'][iPt], True)
-                massFitterOuts[iPt].IncludeSecondGausPeak(massDplus, False, fitConfig['SigmaSecPeak'][iPt], True)
+                massFitterIns[iPt].IncludeSecondGausPeak(massDplus, False, fitConfig['SigmaSecPeak'][iPt], True, fitConfig.get('FixVnSecPeakToSgn', False))
+                massFitterOuts[iPt].IncludeSecondGausPeak(massDplus, False, fitConfig['SigmaSecPeak'][iPt], True, fitConfig.get('FixVnSecPeakToSgn', False))
             # TODO: Add reflections for D0
             # Reflections for D0
             if useRefl:
@@ -750,7 +825,6 @@ def get_vn_vs_mass(fitConfigFileName, centClass, inFileName,
                 suffix_pdf = ')'
             else:
                 suffix_pdf = ''
-
             if len(ptMins)==1:
                 cSimFit[iPt].SaveAs(f'{outputdir}/SimFit{suffix}_{particleName}.pdf')
             else:
@@ -761,18 +835,22 @@ def get_vn_vs_mass(fitConfigFileName, centClass, inFileName,
         for canv in cSimFit:
             canv.Write()
         for hist in hMass:
-            hist.Write()
+            hist.Write('hist_mass')
         for hist in hVn:
-            hist.Write()
+            hist.Write('hist_vn')
         for ipt, (ptmin, ptmax) in enumerate(zip(ptMins, ptMaxs)):
-            fTotFuncMass[ipt].Write(f'fTotFuncMass_pt{ptmin*10:.0f}_{ptmax*10:.0f}')
-            fTotFuncVn[ipt].Write(f'fTotFuncVn_pt{ptmin*10:.0f}_{ptmax*10:.0f}')
-            fSgnFuncMass[ipt].Write(f'fSgnFuncMass_pt{ptmin*10:.0f}_{ptmax*10:.0f}')
-            fBkgFuncMass[ipt].Write(f'fBkgFuncMass_pt{ptmin*10:.0f}_{ptmax*10:.0f}')
-            fBkgFuncVn[ipt].Write(f'fBkgFuncVn_pt{ptmin*10:.0f}_{ptmax*10:.0f}')
-            if fitConfig.get('IncludeKDETempls'):
-                for iFlag in range(len(KDEtemplatesFuncts[ipt])):
-                    KDEtemplatesFuncts[ipt][iFlag].Write(f'{fitConfig["TemplsTreeNames"][iFlag]}_pt{ptmin*10:.0f}_{ptmax*10:.0f}_flag{fitConfig["TemplsFlags"][iFlag]}')
+            if fitConfig['IncludeKDETempls'][ipt]:
+                for iFlag in range(len(cTemplOverlap[ipt])):
+                    cTemplOverlap[ipt][iFlag].Write(f'cOverlap_pt{ptmin*10:.0f}_{ptmax*10:.0f}')
+            try:
+                fTotFuncMass[ipt].Write(f'fTotFuncMass_pt{ptmin*10:.0f}_{ptmax*10:.0f}')
+                fTotFuncVn[ipt].Write(f'fTotFuncVn_pt{ptmin*10:.0f}_{ptmax*10:.0f}')
+                fSgnFuncMass[ipt].Write(f'fSgnFuncMass_pt{ptmin*10:.0f}_{ptmax*10:.0f}')
+                fBkgFuncMass[ipt].Write(f'fBkgFuncMass_pt{ptmin*10:.0f}_{ptmax*10:.0f}')
+                fBkgFuncVn[ipt].Write(f'fBkgFuncVn_pt{ptmin*10:.0f}_{ptmax*10:.0f}')
+            except:
+                print(f'WARNING: Fit failed for pt {ptmin*10:.0f}-{ptmax*10:.0f}')
+                
                 
         hSigmaSimFit.Write()
         hMeanSimFit.Write()
@@ -824,6 +902,10 @@ def get_vn_vs_mass(fitConfigFileName, centClass, inFileName,
     if secPeak:
         gvnSimFitSecPeak.Write()
         gvnUncSecPeak.Write()
+    if useTemplates:
+        for iTempl in range(len(fitConfig['TemplsFlags'])):
+            gvnTempls[iTempl].Write()
+            gvnTemplsUncs[iTempl].Write()
     hist_reso.Write()
 
     outFile.Close()

--- a/run3/flow/invmassfitter/InvMassFitter.cxx
+++ b/run3/flow/invmassfitter/InvMassFitter.cxx
@@ -495,11 +495,11 @@ TF1* InvMassFitter::CreateTemplatesFunction(TString fname){
   TF1* functempl =  new TF1(fname.Data(),this,&InvMassFitter::FitFunction4Templ,fMinMass,fMaxMass,this->fTemplatesFuncts.size(),"InvMassFitter","FitFunction4Templ");
   for(int iPar=0; iPar<functempl->GetNpar(); iPar++) {
     functempl->SetParName(iPar, Form("w_%s",this->fTemplatesFuncts[iPar].GetName()));
-    if(this->fWeightsLowerLims[iPar] >= this->fWeightsUpperLims[iPar]) {
-      functempl->FixParameter(iPar,this->fInitWeights[iPar]);
+    if(this->fMassWeightsLowerLims[iPar] >= this->fMassWeightsUpperLims[iPar]) {
+      functempl->FixParameter(iPar,this->fMassInitWeights[iPar]);
     } else {
-      functempl->SetParameter(iPar,this->fInitWeights[iPar]);
-      functempl->SetParLimits(iPar,this->fWeightsLowerLims[iPar],this->fWeightsUpperLims[iPar]);
+      functempl->SetParameter(iPar,this->fMassInitWeights[iPar]);
+      functempl->SetParLimits(iPar,this->fMassWeightsLowerLims[iPar],this->fMassWeightsUpperLims[iPar]);
     }
   }
   return functempl;

--- a/run3/flow/invmassfitter/InvMassFitter.h
+++ b/run3/flow/invmassfitter/InvMassFitter.h
@@ -9,7 +9,7 @@ class TH1F;
 class InvMassFitter : public TNamed {
  public:
 
-  enum ETypeOfBkg{ kExpo=0, kLin=1, kPol2=2, kNoBk=3, kPow=4, kPowEx=5};
+  enum ETypeOfBkg{ kExpo=0, kLin=1, kPol2=2, kNoBk=3, kPow=4, kPowEx=5, kPol3=6};
   enum ETypeOfSgn{ kGaus=0, k2Gaus=1, k2GausSigmaRatioPar=2 };
   InvMassFitter();
   InvMassFitter(const TH1F* histoToFit, Double_t minvalue, Double_t maxvalue, Int_t fittypeb=kExpo, Int_t fittypes=kGaus);
@@ -102,9 +102,9 @@ class InvMassFitter : public TNamed {
   void SetTemplates(std::vector<TF1> templates, std::vector<Double_t> initweights,
                     std::vector<Double_t> minweights, std::vector<Double_t> maxweights) {
     fTemplatesFuncts=templates;
-    fInitWeights=initweights;
-    fWeightsLowerLims=minweights;
-    fWeightsUpperLims=maxweights;
+    fMassInitWeights=initweights;
+    fMassWeightsLowerLims=minweights;
+    fMassWeightsUpperLims=maxweights;
     fTemplates=kTRUE;
   }
 
@@ -258,9 +258,9 @@ class InvMassFitter : public TNamed {
   TF1*                  fTemplFunc;            /// fit function for templates
   Bool_t                fTemplates;            /// flag use/not use templates fit functions
   Int_t                 fNParsTempls;          /// fit parameters in templates fit function
-  std::vector<Double_t> fWeightsUpperLims;     /// upper limit of the templates' weights
-  std::vector<Double_t> fWeightsLowerLims;     /// lower limit of the templates' weights
-  std::vector<Double_t> fInitWeights;          /// init value of the templates' weights
+  std::vector<Double_t> fMassWeightsUpperLims;     /// upper limit of the templates' weights
+  std::vector<Double_t> fMassWeightsLowerLims;     /// lower limit of the templates' weights
+  std::vector<Double_t> fMassInitWeights;          /// init value of the templates' weights
   
   /// \cond CLASSIMP     
   ClassDef(InvMassFitter,9); /// class for invariant mass fit

--- a/run3/flow/invmassfitter/VnVsMassFitter.h
+++ b/run3/flow/invmassfitter/VnVsMassFitter.h
@@ -62,19 +62,27 @@ public:
     fMaxRefl=maxRange;
     fReflections=kTRUE;
   }
-  void SetKDETemplates(std::vector<TF1> templs, std::vector<std::string> templsnames,
-                       std::vector<Double_t> initweights, std::vector<Double_t> minweights, 
-                       std::vector<Double_t> maxweights) {
-    printf("WARNING: Vn parameter of templates will be the same as the one of the signal! \n");
+  void SetKDETemplates(std::vector<TF1> templs, std::vector<int> templsnames,
+                       std::vector<Double_t> initweights, std::vector<Double_t> minweights, std::vector<Double_t> maxweights, 
+                       std::vector<Double_t> vninitweights, std::vector<Double_t> vnminweights, std::vector<Double_t> vnmaxweights, 
+                       Bool_t samevnofsignal) {
     fKDETemplates=templs;
-    fInitWeights=initweights;
-    fWeightsLowerLims=minweights;
-    fWeightsUpperLims=maxweights;
+    fMassInitWeights=initweights;
+    fMassWeightsLowerLims=minweights;
+    fMassWeightsUpperLims=maxweights;
+    fVnInitWeights=vninitweights;
+    fVnWeightsLowerLims=vnminweights;
+    fVnWeightsUpperLims=vnmaxweights;
     for(int iFunc=0; iFunc<fKDETemplates.size(); iFunc++) {
-      fKDETemplates[iFunc].SetName(templsnames[iFunc].data());
-      fKDETemplates[iFunc].SetTitle(templsnames[iFunc].data());
+      fKDETemplates[iFunc].SetName(Form("TemplFlag_%i", templsnames[iFunc]));
+      fKDETemplates[iFunc].SetTitle(Form("TemplFlag_%i", templsnames[iFunc]));
     }
+    if(samevnofsignal) {printf("WARNING: Vn parameter of templates will be the same as the one of the signal! \n");}
+    fTemplSameVnOfSignal=samevnofsignal;
     fTemplates=kTRUE;
+  }
+  void SetBkgPars(std::vector<Double_t> initpars) {
+    fMassBkgInitPars = initpars;
   }
   void SetInitialReflOverS(Double_t rovers){fRflOverSig=rovers;}
   void SetFixReflOverS(Double_t rovers){
@@ -87,10 +95,11 @@ public:
     fVnRflMin=min;
     fVnRflMax=max;
   }
-  void IncludeSecondGausPeak(Double_t mass, Bool_t fixm, Double_t width, Bool_t fixw, Bool_t doVn){
+  void IncludeSecondGausPeak(Double_t mass, Bool_t fixm, Double_t width, Bool_t fixw, Bool_t doVn, Bool_t fixtosgn){
     fSecondPeak=kTRUE; fSecMass=mass; fSecWidth=width;
     fFixSecMass=fixm;  fFixSecWidth=fixw;
     fDoSecondPeakVn=doVn;
+    fFixVnSecPeakToSgn=fixtosgn;
   }
   void SetHarmonic(Int_t harmonic=2) {fHarmonic=harmonic;}
 
@@ -131,6 +140,32 @@ public:
     if(fMassTotFunc) return fMassTotFunc;
     else return nullptr;
   }
+  Int_t GetNMassBkgPars() const {
+    return fNParsMassBkg;
+  }
+  Int_t GetNMassSgnPars() const {
+    return fNParsMassSgn;
+  }
+  Int_t GetNMassSecPeakPars() const {
+    // only for gaussian case
+    return 3;
+  }
+  Int_t GetNMassReflPars() const {
+    // only for gaussian case
+    return fNParsRfl;
+  }
+  Int_t GetNVnBkgPars() const {
+    return fNParsVnBkg;
+  }
+  Int_t GetNVnSgnPars() const {
+    return fNParsVnSgn;
+  }
+  Int_t GetNVnSecPeakPars() const {
+    return fNParsVnSecPeak;
+  }
+  Int_t GetNVnReflPars() const {
+    return fNParsVnRfl;
+  }
   TF1* GetMassSignalFitFunc() const {
     if(fMassSgnFunc) return fMassSgnFunc;
     else return nullptr;
@@ -155,15 +190,51 @@ public:
     if(fReflections) return fMassBkgRflFunc;
     else return nullptr;
   }
+  TF1* GetMassSecPeakFunc() const {
+    if(fSecondPeak) return fMassSecPeakFunc;
+    else return nullptr;
+  }
+  TF1* GetVnSecPeakFunc() const {
+    if(fSecondPeak) return fVnSecPeakFunc;
+    else return nullptr;
+  }
   std::vector<TF1*> GetMassTemplFuncts() const {
     if(fTemplates) return fKDEMassTemplatesDraw;
     else return {};
   }
-  std::vector<TF1*> GetVnTemplFuncts() const {
-    if(fTemplates) return fKDEVnTemplatesDraw;
+  std::vector<TF1*> GetVnCompsFuncts() const {
+    return fVnCompsDraw;
+  }
+  std::vector<TF1> GetKDEs() const {
+    if(fTemplates) return fKDETemplates;
     else return {};
   }
-
+  std::vector<double> GetVnTemplates() const {
+    std::vector<double> vnPars;
+    if(!fTemplSameVnOfSignal) {
+      for(int iFunc=0; iFunc<fKDETemplates.size(); iFunc++) {
+        vnPars.push_back(fVnTotFunc->GetParameter(iFunc+fNParsMassSgn+fNParsMassBkg+fNParsSec+fNParsRfl+fNParsTempls+fNParsVnBkg+fNParsVnSgn+fNParsVnSecPeak+fNParsRfl));
+      }
+    } else {
+      for(int iFunc=0; iFunc<fKDETemplates.size(); iFunc++) {
+        vnPars.push_back(GetVn());
+      }
+    }
+    return vnPars;
+  }
+  std::vector<double> GetVnTemplatesUncertainties() const {
+    std::vector<double> vnPars;
+    if(!fTemplSameVnOfSignal) {
+      for(int iFunc=0; iFunc<fKDETemplates.size(); iFunc++) {
+        vnPars.push_back(fVnTotFunc->GetParError(iFunc+fNParsMassSgn+fNParsMassBkg+fNParsSec+fNParsRfl+fNParsTempls+fNParsVnBkg+fNParsVnSgn+fNParsVnSecPeak+fNParsRfl));
+      }
+    } else {
+      for(int iFunc=0; iFunc<fKDETemplates.size(); iFunc++) {
+        vnPars.push_back(GetVnUncertainty());
+      }
+    }
+    return vnPars;
+  }
   //struct for global chi2 (for simultaneus fit)
   struct GlobalChi2 {
     GlobalChi2(ROOT::Math::IMultiGenFunction & f1,ROOT::Math::IMultiGenFunction & f2) : fChi2_1(&f1), fChi2_2(&f2) {}
@@ -193,6 +264,7 @@ private:
   Double_t MassFunc(Double_t *m, Double_t *pars);
   Double_t vnBkgFunc(Double_t *m, Double_t *pars);
   Double_t vnFunc(Double_t *m, Double_t *pars);
+  Double_t VnTemplates(Double_t *m,Double_t *pars);
 
     ///private methods
   void DefineNumberOfParameters();
@@ -202,96 +274,103 @@ private:
   void SetParNames();
 
     ///data members
-  TH1F*                 fMassHisto;                   /// mass histogram to fit
-  TH1F*                 fVnVsMassHisto;               /// vn vs. mass histogram to fit
-  Int_t                 fMassSgnFuncType;             /// type of mass signal fit function
-  Int_t                 fMassBkgFuncType;             /// type of mass bkg fit function
-  Int_t                 fVnBkgFuncType;               /// type of vn bkg fit function
-  TF1*                  fMassFuncFromPrefit;          /// mass fit function (1st step, from prefit)
-  TF1*                  fMassBkgFunc;                 /// mass bkg fit function (final, after simultaneus fit)
-  TF1*                  fMassSgnFunc;                 /// mass signal fit function (final, after simultaneus fit)
-  TF1*                  fMassTotFunc;                 /// mass fit function (final, after simultaneus fit)
-  TF1*                  fVnBkgFuncSb;                 /// vn bkg fit function (1st step from SB prefit)
-  TF1*                  fVnBkgFunc;                   /// vn bkg fit function (final, after simultaneus fit)
-  TF1*                  fVnTotFunc;                   /// vn fit function (final, after simultaneus fit)
-  InvMassFitter*        fMassFitter;                  /// mass fitter for mass prefit
-  Double_t              fMassMin;                     /// upper mass limit
-  Double_t              fMassMax;                     /// lower mass limit
-  Double_t              fVn;                          /// vn of the signal from fit
-  Double_t              fVnUncertainty;               /// uncertainty on vn of the signal from simultaneus fit
-  Double_t              fSigma;                       /// mass peak width from simultaneus fit
-  Double_t              fSigmaUncertainty;            /// uncertainty on mass peak width from simultaneus fit
-  Double_t              fMean;                        /// mass peak position from simultaneus fit
-  Double_t              fMeanUncertainty;             /// uncertainty on mass peak position from simultaneus fit
-  Double_t              fRawYield;                    /// raw yield from simultaneus fit
-  Double_t              fRawYieldUncertainty;         /// uncertainty raw yield from simultaneus fit
-  Double_t              fChiSquare;                   /// simultaneus fit chi square
-  Int_t                 fNDF;                         /// simultaneus fit number of degree of freedom
-  Double_t              fProb;                        /// simultaneus fit probability
-  Double_t              fSBVnPrefitChiSquare;         /// vn SB prefit chi square
-  Int_t                 fSBVnPrefitNDF;               /// vn SB prefit number of degree of freedom
-  Double_t              fSBVnPrefitProb;              /// vn SB prefit probability
-  Double_t              fMassPrefitChiSquare;         /// Mass prefit chi square
-  Int_t                 fMassPrefitNDF;               /// Mass prefit number of degree of freedom
-  Double_t              fMassPrefitProb;              /// Mass prefit probability
-  Int_t                 fNSigmaForSB;                 /// number of sigma for sidebands region (vn bkg prefit)
-  Double_t              fSigmaInit;                   /// initialization for peak width
-  Double_t              fMeanInit;                    /// initialization for peak position
-  Double_t              fSigma2GausInit;              /// initialization for second peak width in case of k2Gaus
-  Double_t              fFrac2GausInit;               /// initialization for fraction of second gaussian in case of k2Gaus
-  Bool_t                fMeanFixedFromMassFit;        /// flag to fix peak position from mass prefit
-  Bool_t                fSigmaFixedFromMassFit;       /// flag to fix peak width from mass prefit
-  Bool_t                fSigma2GausFixedFromMassFit;  /// flag to fix second peak width from mass prefit in case of k2Gaus
-  Bool_t                fFrac2GausFixedFromMassFit;   /// flag to fix fraction of second gaussian in case of k2Gaus
-  Double_t              fMassParticle;                /// mass of selected particle
-  Int_t                 fNParsMassSgn;                /// number of parameters in mass signal fit function
-  Int_t                 fNParsMassBkg;                /// number of parameters in mass bkg fit function
-  Int_t                 fNParsVnBkg;                  /// number of parameters in vn bkg fit function
-  Int_t                 fNParsVnSgn;                  /// number of parameters in vn sgn fit function (1)
-  Int_t                 fNParsVnSecPeak;              /// number of parameters in vn sec peak fit function (1 if included, 0 otherwise)
-  Int_t                 fNParsVnRfl;                  /// number of parameters in vn refl fit function (1 if included, 0 otherwise)
-  Int_t                 fSigmaFixed;                  /// flag to fix peak width
-  Int_t                 fMeanFixed;                   /// flag to fix peak position
-  Int_t                 fSigma2GausFixed;             /// flag to fix second peak width in case of k2Gaus
-  Int_t                 fFrac2GausFixed;              /// flag to fix fraction of second gaussian in case of k2Gaus
-  Int_t                 fPolDegreeBkg;                /// degree of polynomial expansion for back fit (option 6 for back)
-  Int_t                 fPolDegreeVnBkg;              /// degree of polynomial expansion for vn back fit (option 6 for back)
-  Bool_t                fReflections;                 /// flag use/not use reflections
-  Int_t                 fNParsRfl;                    /// fit parameters in reflection fit function
-  Double_t              fRflOverSig;                  /// reflection/signal
-  Bool_t                fFixRflOverSig;               /// switch for fix refl/signal
-  TH1F*                 fHistoTemplRfl;               /// histogram with reflection template
-  TH1F*                 fHistoTemplRflInit;           /// initial histogram with reflection template
-  TF1*                  fMassRflFunc;                 /// fit function for reflections
-  TF1*                  fMassBkgRflFunc;              /// mass bkg fit function plus reflections (final, after simultaneus fit)
-  TString               fRflOpt;                      /// refelction option
-  Double_t              fMinRefl;                     /// minimum for refelction histo
-  Double_t              fMaxRefl;                     /// maximum for refelction histo
-  Bool_t                fSmoothRfl;                   /// switch for smoothing of reflection template
-  Double_t              fRawYieldHelp;                /// internal variable for fit with reflections
-  Int_t                 fVnRflOpt;                    /// option for reflection vn type
-  Bool_t                fVnRflLimited;                /// flag to limit or not the vn of reflections
-  Double_t              fVnRflMin;                    /// minimum vn of reflections
-  Double_t              fVnRflMax;                    /// maximum vn of reflections
-  Bool_t                fSecondPeak;                  /// switch off/on second peak (for D+->KKpi in Ds)
-  TF1*                  fMassSecPeakFunc;             /// fit function for second peak
-  Int_t                 fNParsSec;                    /// number of parameters in second peak fit function
-  Double_t              fSecMass;                     /// position of the 2nd peak
-  Double_t              fSecWidth;                    /// width of the 2nd peak
-  Bool_t                fFixSecMass;                  /// flag to fix the position of the 2nd peak
-  Bool_t                fFixSecWidth;                 /// flag to fix the width of the 2nd peak
-  Double_t              fVnSecPeak;                   /// vn of second peak from fit
-  Bool_t                fDoSecondPeakVn;              /// flag to introduce second peak vn in the vn vs. mass fit
-  Double_t              fVnSecPeakUncertainty;        /// vn uncertainty of second peak from fit
-  Int_t                 fHarmonic;                    /// harmonic number for drawing
-  Bool_t                fTemplates;                   /// flag use/not use templates
-  Int_t                 fNParsTempls;                 /// fit parameters to include templates
-  std::vector<TF1>      fKDETemplates;                /// vector to store TKDE to be added as templates to the fit function 
-  std::vector<TF1 *>    fKDEVnTemplatesDraw;          /// vector to store TKDE to be added as templates to the fit function 
-  std::vector<TF1 *>    fKDEMassTemplatesDraw;        /// vector to store TKDE to be added as templates to the fit function 
-  std::vector<Double_t> fWeightsUpperLims;            /// upper limit of the templates' weights
-  std::vector<Double_t> fWeightsLowerLims;            /// lower limit of the templates' weights
-  std::vector<Double_t> fInitWeights;                 /// init values of the templates' weights
+  TH1F*                 fMassHisto;                     /// mass histogram to fit
+  TH1F*                 fVnVsMassHisto;                 /// vn vs. mass histogram to fit
+  Int_t                 fMassSgnFuncType;               /// type of mass signal fit function
+  Int_t                 fMassBkgFuncType;               /// type of mass bkg fit function
+  Int_t                 fVnBkgFuncType;                 /// type of vn bkg fit function
+  TF1*                  fMassFuncFromPrefit;            /// mass fit function (1st step, from prefit)
+  TF1*                  fMassBkgFunc;                   /// mass bkg fit function (final, after simultaneus fit)
+  TF1*                  fMassSgnFunc;                   /// mass signal fit function (final, after simultaneus fit)
+  TF1*                  fMassTotFunc;                   /// mass fit function (final, after simultaneus fit)
+  TF1*                  fVnBkgFuncSb;                   /// vn bkg fit function (1st step from SB prefit)
+  TF1*                  fVnBkgFunc;                     /// vn bkg fit function (final, after simultaneus fit)
+  TF1*                  fVnTotFunc;                     /// vn fit function (final, after simultaneus fit)
+  InvMassFitter*        fMassFitter;                    /// mass fitter for mass prefit
+  Double_t              fMassMin;                       /// upper mass limit
+  Double_t              fMassMax;                       /// lower mass limit
+  Double_t              fVn;                            /// vn of the signal from fit
+  Double_t              fVnUncertainty;                 /// uncertainty on vn of the signal from simultaneus fit
+  Double_t              fSigma;                         /// mass peak width from simultaneus fit
+  Double_t              fSigmaUncertainty;              /// uncertainty on mass peak width from simultaneus fit
+  Double_t              fMean;                          /// mass peak position from simultaneus fit
+  Double_t              fMeanUncertainty;               /// uncertainty on mass peak position from simultaneus fit
+  Double_t              fRawYield;                      /// raw yield from simultaneus fit
+  Double_t              fRawYieldUncertainty;           /// uncertainty raw yield from simultaneus fit
+  Double_t              fChiSquare;                     /// simultaneus fit chi square
+  Int_t                 fNDF;                           /// simultaneus fit number of degree of freedom
+  Double_t              fProb;                          /// simultaneus fit probability
+  Double_t              fSBVnPrefitChiSquare;           /// vn SB prefit chi square
+  Int_t                 fSBVnPrefitNDF;                 /// vn SB prefit number of degree of freedom
+  Double_t              fSBVnPrefitProb;                /// vn SB prefit probability
+  Double_t              fMassPrefitChiSquare;           /// Mass prefit chi square
+  Int_t                 fMassPrefitNDF;                 /// Mass prefit number of degree of freedom
+  Double_t              fMassPrefitProb;                /// Mass prefit probability
+  Int_t                 fNSigmaForSB;                   /// number of sigma for sidebands region (vn bkg prefit)
+  Double_t              fSigmaInit;                     /// initialization for peak width
+  Double_t              fMeanInit;                      /// initialization for peak position
+  Double_t              fSigma2GausInit;                /// initialization for second peak width in case of k2Gaus
+  Double_t              fFrac2GausInit;                 /// initialization for fraction of second gaussian in case of k2Gaus
+  Bool_t                fMeanFixedFromMassFit;          /// flag to fix peak position from mass prefit
+  Bool_t                fSigmaFixedFromMassFit;         /// flag to fix peak width from mass prefit
+  Bool_t                fSigma2GausFixedFromMassFit;    /// flag to fix second peak width from mass prefit in case of k2Gaus
+  Bool_t                fFrac2GausFixedFromMassFit;     /// flag to fix fraction of second gaussian in case of k2Gaus
+  Double_t              fMassParticle;                  /// mass of selected particle
+  Int_t                 fNParsMassSgn;                  /// number of parameters in mass signal fit function
+  Int_t                 fNParsMassBkg;                  /// number of parameters in mass bkg fit function
+  Int_t                 fNParsVnBkg;                    /// number of parameters in vn bkg fit function
+  Int_t                 fNParsVnSgn;                    /// number of parameters in vn sgn fit function (1)
+  Int_t                 fNParsVnSecPeak;                /// number of parameters in vn sec peak fit function (1 if included, 0 otherwise)
+  Int_t                 fNParsVnRfl;                    /// number of parameters in vn refl fit function (1 if included, 0 otherwise)
+  Int_t                 fSigmaFixed;                    /// flag to fix peak width
+  Int_t                 fMeanFixed;                     /// flag to fix peak position
+  Int_t                 fSigma2GausFixed;               /// flag to fix second peak width in case of k2Gaus
+  Int_t                 fFrac2GausFixed;                /// flag to fix fraction of second gaussian in case of k2Gaus
+  std::vector<Double_t> fMassBkgInitPars;               /// init values of the templates' weights
+  Int_t                 fPolDegreeBkg;                  /// degree of polynomial expansion for back fit (option 6 for back)
+  Int_t                 fPolDegreeVnBkg;                /// degree of polynomial expansion for vn back fit (option 6 for back)
+  Bool_t                fReflections;                   /// flag use/not use reflections
+  Int_t                 fNParsRfl;                      /// fit parameters in reflection fit function
+  Double_t              fRflOverSig;                    /// reflection/signal
+  Bool_t                fFixRflOverSig;                 /// switch for fix refl/signal
+  TH1F*                 fHistoTemplRfl;                 /// histogram with reflection template
+  TH1F*                 fHistoTemplRflInit;             /// initial histogram with reflection template
+  TF1*                  fMassRflFunc;                   /// fit function for reflections
+  TF1*                  fMassBkgRflFunc;                /// mass bkg fit function plus reflections (final, after simultaneus fit)
+  TString               fRflOpt;                        /// refelction option
+  Double_t              fMinRefl;                       /// minimum for refelction histo
+  Double_t              fMaxRefl;                       /// maximum for refelction histo
+  Bool_t                fSmoothRfl;                     /// switch for smoothing of reflection template
+  Double_t              fRawYieldHelp;                  /// internal variable for fit with reflections
+  Int_t                 fVnRflOpt;                      /// option for reflection vn type
+  Bool_t                fVnRflLimited;                  /// flag to limit or not the vn of reflections
+  Double_t              fVnRflMin;                      /// minimum vn of reflections
+  Double_t              fVnRflMax;                      /// maximum vn of reflections
+  Bool_t                fSecondPeak;                    /// switch off/on second peak (for D+->KKpi in Ds)
+  TF1*                  fMassSecPeakFunc;               /// fit function for second peak
+  TF1*                  fVnSecPeakFunc;                 /// fit function for second peak
+  Int_t                 fNParsSec;                      /// number of parameters in second peak fit function
+  Double_t              fSecMass;                       /// position of the 2nd peak
+  Double_t              fSecWidth;                      /// width of the 2nd peak
+  Bool_t                fFixSecMass;                    /// flag to fix the position of the 2nd peak
+  Bool_t                fFixSecWidth;                   /// flag to fix the width of the 2nd peak
+  Double_t              fVnSecPeak;                     /// vn of second peak from fit
+  Bool_t                fDoSecondPeakVn;                /// flag to introduce second peak vn in the vn vs. mass fit
+  Bool_t                fFixVnSecPeakToSgn;             /// flag to fix the vn of the second peak to the one of signal
+  Double_t              fVnSecPeakUncertainty;          /// vn uncertainty of second peak from fit
+  Int_t                 fHarmonic;                      /// harmonic number for drawing
+  Bool_t                fTemplates;                     /// flag use/not use templates
+  Int_t                 fNParsTempls;                   /// fit parameters to include templates
+  std::vector<TF1>      fKDETemplates;                  /// vector to store TKDE to be added as templates to the fit function 
+  std::vector<TF1 *>    fVnCompsDraw;                   /// vector to store TKDE to be added as templates to the fit function 
+  std::vector<TF1 *>    fKDEMassTemplatesDraw;          /// vector to store TKDE to be added as templates to the fit function 
+  std::vector<Double_t> fMassWeightsUpperLims;          /// upper limit of the templates' weights
+  std::vector<Double_t> fMassWeightsLowerLims;          /// lower limit of the templates' weights
+  std::vector<Double_t> fVnWeightsUpperLims;            /// upper limit of the templates' weights
+  std::vector<Double_t> fVnWeightsLowerLims;            /// lower limit of the templates' weights
+  std::vector<Double_t> fMassInitWeights;               /// init values of the templates' weights
+  std::vector<Double_t> fVnInitWeights;                 /// init values of the templates' weights
+  Bool_t                fTemplSameVnOfSignal;           /// init values of the templates' weights
 
     /// \cond CLASSDEF
   ClassDef(VnVsMassFitter,5);

--- a/run3/flow/kde_producer.py
+++ b/run3/flow/kde_producer.py
@@ -19,28 +19,31 @@ def kde_producer(tree_file, var, pt_min, pt_max, flag, outfile='', tree_name='O2
                 dfsData.append(dfData)      
     full_dataset = pd.concat([df for df in dfsData], ignore_index=True)
     pt_filtered_df = full_dataset.query(f"{pt_min} <= fPt < {pt_max}")
-    filtered_df = pt_filtered_df.query(f"fFlagMcMatchRec == {flag} or fFlagMcMatchRec == {-flag}")
+    filtered_df = pt_filtered_df.query(f"fFlagMcDecayChanRec == {flag} or fFlagMcDecayChanRec == {-flag}")
     var_values = filtered_df[f'{var}'].tolist()  # Or use `.tolist()` to get a list
-    
-    kde = TKDE(len(var_values), np.asarray(var_values, 'd'), 1.7, 2.0)
+
+    kde = TKDE(len(var_values), np.asarray(var_values, 'd'), min(var_values), max(var_values))
     kde_func = kde.GetFunction(1000)
     
-    binned_var_values = TH1D(f'hBinned', f'hBinned', 5000, 1, 3)
+    binned_var_values = TH1D(f'hBinned', f'hBinned', 100, min(var_values), max(var_values))
     for var_value in var_values:
         binned_var_values.Fill(var_value)
     
-    if outfile != '':
-        cOverlap = TCanvas('cOverlap', 'cOverlap', 600, 600)
-        cOverlap.cd()
-        binned_var_values.Draw()
-        kde_func.Draw('same')
-        outfile.mkdir(f'KDE_pT_{pt_low}_{pt_max}_flag{flag}')
-        outfile.cd(f'KDE_pT_{pt_low}_{pt_max}_flag{flag}')
-        binned_var_values.Write()
-        kde_func.Write()
-        cOverlap.Write()
+    max_content = 0
+    for bin_idx in range(1, binned_var_values.GetNbinsX() + 1):
+        bin_content = binned_var_values.GetBinContent(bin_idx)
+        if bin_content > max_content:
+            max_content = bin_content
+            max_bin = bin_idx
+    binned_var_values.Scale(kde_func.GetMaximum() / binned_var_values.GetBinContent(max_bin))
     
-    return kde 
+    if outfile != '':
+        outfile.mkdir(f'KDE_pT_{pt_min}_{pt_max}_flag{flag}')
+        outfile.cd(f'KDE_pT_{pt_min}_{pt_max}_flag{flag}')
+        kde_func.Write()
+        binned_var_values.Write()
+    
+    return kde, kde_func, binned_var_values
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Arguments")
@@ -75,9 +78,9 @@ if __name__ == "__main__":
         
     if args.config != parser.get_default("config"):
         for pt_low, pt_max in zip(config['pt_mins'], config['pt_maxs']):
-            KDE, histo = kde_producer_grid(config['input'], config['variable'], pt_low, 
+            KDE, histo = kde_producer(config['input'], config['variable'], pt_low, 
                                            pt_max, config['chn_flag'], outfile)
     else:
-        KDE, histo = kde_producer_grid(args.input, args.var, args.ptmin,
+        KDE, histo = kde_producer(args.input, args.var, args.ptmin,
                                        args.ptmax, args.flag, outfile)
     outfile.Close()    


### PR DESCRIPTION
This PR introduces the following improvements for KDE fitting:
- possibility to draw vn components of fit function
- print of the vn parameters for templates
- initialization of template weights both for mass and vn coefficient 
- possibility to fix the vn of the template to the one of the signal
- possibility to initialize the mass background function coefficients