### PR TITLE
Pre process update

### DIFF
--- a/run3/flow/BDT/sparse_dicts.py
+++ b/run3/flow/BDT/sparse_dicts.py
@@ -1,0 +1,188 @@
+import ROOT
+from ROOT import TFile
+
+def get_sparses(config, get_data, get_mc_reco, get_mc_gen, preprocessed=False, preprocess_dir=''):
+    
+    sparsesFlow, sparsesReco, sparsesGen, axes_dict = {}, {}, {}, {}    
+    
+    if get_data:
+        if preprocessed:
+            axes_dict['Flow'] = {ax: iax for iax, ax in enumerate(config['axestokeep'])}
+            for ptmin, ptmax in zip(config['ptmins'], config['ptmaxs']):
+                print(f"Loading flow sparse from file: {preprocess_dir}/AnalysisResults_pt_{int(ptmin*10)}_{int(ptmax*10)}.root")
+                infileflow = ROOT.TFile(f"{preprocess_dir}/AnalysisResults_pt_{int(ptmin*10)}_{int(ptmax*10)}.root")
+                sparsesFlow[f'Flow_{ptmin*10}_{ptmax*10}'] = infileflow.Get('hf-task-flow-charm-hadrons/hSparseFlowCharm')
+                infileflow.Close()
+        else:
+            axes_dict['Flow'] = {
+                'Mass': 0,
+                'Pt': 1,
+                'cent': 2,
+                'sp': 3,
+                'score_bkg': 4,
+                'score_FD': 5,
+                'occ': 6
+            }
+            for ifile, file in enumerate(config['flow_files']):
+                print(f"Loading flow sparse from file: {file}")
+                infileflow = ROOT.TFile(file)
+                sparsesFlow[f'Flow_{ifile}'] = infileflow.Get('hf-task-flow-charm-hadrons/hSparseFlowCharm')
+                infileflow.Close()
+       
+    if get_mc_gen or get_mc_reco:
+        print(f"Loading mc sparse from: {config['eff_filename']}")
+        infiletask = ROOT.TFile(config['eff_filename'])
+    
+    if get_mc_reco: 
+        if config['Dmeson'] == 'Dzero':
+            axes_reco = {
+                'score_bkg': 0,
+                'score_FD': 1,
+                'score_prompt': 2,
+                'Mass': 3,
+                'Pt': 4,
+                'y': 5,
+                'cand_type': 6,
+                'pt_bmoth': 7,
+                'origin': 8,
+                'npvcontr': 9,
+                'cent': 10,
+                'occ': 11,
+            }
+            print(f"infiletask: {infiletask}")
+            sparsesReco['RecoPrompt'] = infiletask.Get('hf-task-d0/hBdtScoreVsMassVsPtVsPtBVsYVsOriginVsD0Type')
+            print(f"sparsesReco['RecoPrompt']: {sparsesReco['RecoPrompt']}")
+            print('\n')
+            sparsesReco['RecoPrompt'].GetAxis(axes_reco['origin']).SetRange(1, 2)  # make sure it is signal
+            sparsesReco['RecoPrompt'].GetAxis(axes_reco['cand_type']).SetRange(2, 2) # make sure it is prompt
+            axes_dict['RecoPrompt'] = axes_reco
+            sparsesReco['RecoFD'] = infiletask.Get('hf-task-d0/hBdtScoreVsMassVsPtVsPtBVsYVsOriginVsD0Type')
+            sparsesReco['RecoFD'].GetAxis(axes_reco['cand_type']).SetRange(3, 3)  # make sure it is non-prompt
+            sparsesReco['RecoFD'].GetAxis(axes_reco['origin']).SetRange(1, 2)  # make sure it is signal
+            axes_dict['RecoFD'] = axes_reco
+            sparsesReco['RecoRefl'] = infiletask.Get('hf-task-d0/hBdtScoreVsMassVsPtVsPtBVsYVsOriginVsD0Type')
+            sparsesReco['RecoRefl'].GetAxis(axes_reco['origin']).SetRange(3, 4)  # make sure it is reflection
+            axes_dict['RecoRefl'] = axes_reco
+            sparsesReco['RecoReflPrompt'] = infiletask.Get('hf-task-d0/hBdtScoreVsMassVsPtVsPtBVsYVsOriginVsD0Type')
+            sparsesReco['RecoReflPrompt'].GetAxis(axes_reco['origin']).SetRange(3, 4)  # make sure it is reflection
+            sparsesReco['RecoReflPrompt'].GetAxis(axes_reco['cand_type']).SetRange(2, 2) # make sure it is prompt
+            axes_dict['RecoReflPrompt'] = axes_reco
+            sparsesReco['RecoReflFD'] = infiletask.Get('hf-task-d0/hBdtScoreVsMassVsPtVsPtBVsYVsOriginVsD0Type')
+            sparsesReco['RecoReflFD'].GetAxis(axes_reco['origin']).SetRange(3, 4)  # make sure it is reflection
+            sparsesReco['RecoReflFD'].GetAxis(axes_reco['cand_type']).SetRange(3, 3) # make sure it is FD
+            axes_dict['RecoReflFD'] = axes_reco
+            #TODO: safety checks for Dmeson reflecton and secondary peak
+        elif config['Dmeson'] == 'Dplus':
+            sparsesReco['RecoPrompt'] = infiletask.Get('hf-task-dplus/hSparseMassPrompt')
+            axes_dict['RecoPrompt'] = {
+                'Mass': 0,
+                'Pt': 1,
+                'score_bkg': 2,
+                'score_prompt': 3,
+                'score_FD': 4,
+                'cent': 5,
+                'occ': 6,
+            }
+            sparsesReco['RecoFD'] = infiletask.Get('hf-task-dplus/hSparseMassFD')
+            axes_dict['RecoFD'] = {
+                'Mass': 0,
+                'Pt': 1,
+                'pt_bmoth': 2,
+                'flag_bhad': 3,
+                'score_bkg': 4,
+                'score_prompt': 5,
+                'score_FD': 6,
+                'cent': 7,
+                'occ': 8
+            }
+        elif config['Dmeson'] == 'Ds':
+            sparsesReco['RecoPrompt'] = infiletask.Get('hf-task-ds/MC/Ds/Prompt/hSparseMass')
+            axes_dict['RecoPrompt'] = {
+                'Mass': 0,
+                'Pt': 1,
+                'cent': 3,
+                'npvcontr': 4,
+                'score_bkg': 5,
+                'score_prompt': 6,
+                'score_FD': 7,
+                'occ': 8,
+            }
+            sparsesReco['RecoFD'] = infiletask.Get('hf-task-ds/MC/Ds/NonPrompt/hSparseMass')
+            axes_dict['RecoFD'] = {
+                'Mass': 0,
+                'Pt': 1,
+                'cent': 2,
+                'score_bkg': 3,
+                'score_prompt': 4,
+                'score_FD': 5,
+                'pt_bmoth': 6,
+                'flag_bhad': 7,
+                'occ': 8
+            }
+
+    if get_mc_gen: 
+        print(f"Loading mc gen sparse from: {config['eff_filename']}")
+        infiletask = ROOT.TFile(config['eff_filename'])
+        if config['Dmeson'] == 'Dzero':
+            axes_gen = {
+                'Pt': 0,
+                'pt_bmoth': 1,
+                'y': 2,
+                'origin': 3,
+                'cent': 4,
+                'occ': 5
+            }
+            sparsesGen['GenPrompt'] = infiletask.Get('hf-task-d0/hSparseAcc')
+            sparsesGen['GenPrompt'].GetAxis(axes_gen['origin']).SetRange(2, 2)  # make sure it is prompt
+            axes_dict['GenPrompt'] = axes_gen 
+            print(f"sparseGenPrompt: {sparsesGen['GenPrompt']}")
+            sparsesGen['GenFD'] = infiletask.Get('hf-task-d0/hSparseAcc')
+            sparsesGen['GenFD'].GetAxis(axes_gen['origin']).SetRange(3, 3)  # make sure it is non-prompt
+            axes_dict['GenFD'] = axes_gen
+            print(f"sparseGenFD: {sparsesGen['GenFD']}")
+            #TODO: safety checks for Dmeson reflecton and secondary peak
+        elif config['Dmeson'] == 'Dplus':
+            sparsesGen['GenPrompt'] = infiletask.Get('hf-task-dplus/hSparseMassGenPrompt')
+            axes_dict['GenPrompt'] = {
+                'Pt': 0,
+                'y': 1,
+                'cent': 2,
+                'occ': 3
+            }   
+            print(f"sparseGenPrompt: {sparsesGen['GenPrompt']}")
+            sparsesGen['GenFD'] = infiletask.Get('hf-task-dplus/hSparseMassGenFD')
+            axes_dict['GenFD'] = {
+                'Pt': 0,
+                'y': 1,
+                'pt_bmoth': 2,
+                'flag_bhad': 3,
+                'cent': 4,
+                'occ': 5
+            }
+            print(f"sparseGenFD: {sparsesGen['GenFD']}")
+        elif config['Dmeson'] == 'Ds':
+            sparsesGen['GenPrompt'] = infiletask.Get('hf-task-ds/MC/Ds/Prompt/hSparseGen')
+            axes_dict['GenPrompt'] = {
+                'Pt': 0,
+                'y': 1,
+                'npvcontr': 2,
+                'cent': 3,
+                'occ': 4
+            }   
+            print(f"sparseGenPrompt: {sparsesGen['GenPrompt']}")
+            sparsesGen['GenFD'] = infiletask.Get('hf-task-ds/MC/Ds/NonPrompt/hSparseGen')
+            axes_dict['GenFD'] = {
+                'Pt': 0,
+                'y': 1,
+                'cent': 2,
+                'pt_bmoth': 3,
+                'flag_bhad': 4,
+                'occ': 5
+            }
+            print(f"sparseGenFD: {sparsesGen['GenFD']}")
+
+    if get_mc_gen or get_mc_reco:
+        infiletask.Close()
+
+    print(f"Loaded sparses!")
+    return sparsesFlow, sparsesReco, sparsesGen, axes_dict

--- a/run3/tool/config_pre.yml
+++ b/run3/tool/config_pre.yml
@@ -1,96 +1,34 @@
-# ______________________________________________________________________________________________________________________________________________________
-# ptmins: [0,1,  1.5,2,  2.5,3,  3.5,4,5,6,7,8,9 ,10,12,16,24,36] 
-# ptmaxs: [1,1.5,2,  2.5,3,  3.5,4,  5,6,7,8,9,10,12,16,24,36,50]
+### input files to be preprocessed
+flow_files: [
+  /path/to/AnRes_0.root,
+  /path/to/AnRes_1.root,
+  /path/to/AnRes_2.root,
+  /path/to/AnRes_3.root,
+  /path/to/AnRes_4.root,
+  /path/to/AnRes_5.root,
+  /path/to/AnRes_6.root,
+  /path/to/AnRes_7.root,
+  /path/to/AnRes_8.root,
+  /path/to/AnRes_9.root,
+  /path/to/AnRes_10.root,
+]
 
-ptmins: [1, 2, 2.5, 3, 3.5, 4, 5, 6, 7, 8, 10, 12, 16] #, 24, 36] #, 36] #14
-ptmaxs: [2, 2.5, 3, 3.5, 4, 5, 6, 7, 8, 10, 12, 16, 24] #, 36, 50] #, 50]
+# pt ranges to be skimmed
+ptmins: [0.0,0.5,1.0,1.5]
+ptmaxs: [0.5,1.0,1.5,2.0]
 
-# axes config
-    # 'Mass': 0,
-    # 'Pt': 1,
-    # 'cent': 2,
-    # 'sp': 3,
-    # 'score_bkg': 4,
-    # 'score_FD': 5,
-    # 'occ': 6
+# centrality class
+centrality: 'k3040'
+# output directory for preprocessed files
+skim_out_dir: '/Users/mcosti/Analysis/Datasets/3050/skim3040bkgstrict'
+# bkg cuts, cut is applied then bkg axis is dropped
+bkg_cuts: [0.002, 0.002, 0.002, 0.006]
 
-axestokeep: [0, 1, 2, 3, 4, 5]
-outputDir: '/home/wuct/ALICE/local/Results/BDT/full'
-
-config_flow: '/home/wuct/ALICE/local/DmesonAnalysis/run3/flow/Results/2060/k3050/large/sp/config/config_flow_3050l_full.yml'
-centrality: 'k3050'
-resolution: '/media/wuct/wulby/ALICE/AnRes/resolution/output_reso/resospk3050_inte.root'
-
-#______________________________________________________________________________________________________________________________________________________
-# used for the fit
-# global info (do not change)
-axes: {mass: 0,
-       pt: 1,
-       cent: 2,
-       sp: 3,
-       deltaphi: 3,
-       bdt_bkg: 4,
-       bdt_sig: 5}
-
-harmonic: 2 # 2: v2, 3: v3, etc.
-
-# inv_mass_bins (one for each pt bin)
-inv_mass_bins: [ #[1.72,1.76,1.80,1.82,1.83,1.84,1.85,1.86,1.87,1.88,1.89,1.90,1.91,1.92,1.94,1.96,1.98,2.02,2.06], #1
-                [1.72,1.74,1.76,1.78,1.80,1.82,1.83,1.84,1.85,1.86,1.87,1.88,1.89,1.90,1.91,1.92,1.94,1.96,1.98,2.00,2.02,2.04,2.06],
-                [1.72,1.74,1.76,1.78,1.80,1.82,1.83,1.84,1.85,1.86,1.87,1.88,1.89,1.90,1.91,1.92,1.94,1.96,1.98,2.00,2.02,2.04,2.06], #1
-                [1.72,1.74,1.76,1.78,1.80,1.82,1.83,1.84,1.85,1.86,1.87,1.88,1.89,1.90,1.91,1.92,1.94,1.96,1.98,2.00,2.02,2.04,2.06], #2
-                [1.70,1.72,1.74,1.76,1.78,1.80,1.82,1.83,1.84,1.85,1.86,1.87,1.88,1.89,1.90,1.91,1.92,1.94,1.96,1.98,2.00,2.02,2.04,2.06], #3
-                [1.70,1.72,1.74,1.76,1.78,1.80,1.82,1.83,1.84,1.85,1.86,1.87,1.88,1.89,1.90,1.91,1.92,1.94,1.96,1.98,2.00,2.02,2.04,2.06], #4
-                [1.72,1.76,1.80,1.82,1.83,1.84,1.85,1.86,1.87,1.88,1.89,1.90,1.91,1.92,1.94,1.96,1.98,2.02,2.06], #5
-                [1.72,1.76,1.80,1.82,1.83,1.84,1.85,1.86,1.87,1.88,1.89,1.90,1.91,1.92,1.94,1.96,1.98,2.02,2.06], #6
-                #[1.72,1.76,1.80,1.82,1.83,1.84,1.85,1.86,1.87,1.88,1.89,1.90,1.91,1.92,1.94,1.96,1.98,2.02,2.06], #7
-                [1.72,1.76,1.80,1.82,1.84,1.85,1.86,1.87,1.88,1.89,1.90,1.91,1.92,1.94,1.96,1.98,2.02,2.06],
-                [1.72,1.76,1.80,1.82,1.83,1.84,1.85,1.86,1.87,1.88,1.89,1.90,1.91,1.92,1.94,1.96,1.98,2.02,2.06],
-                [1.72,1.76,1.80,1.82,1.83,1.84,1.85,1.86,1.87,1.88,1.89,1.90,1.91,1.92,1.94,1.96,1.98,2.02,2.06],
-                [1.68,1.72,1.76,1.80,1.82,1.83,1.84,1.85,1.86,1.87,1.88,1.89,1.90,1.91,1.92,1.94,1.96,1.98,2.02,2.06],
-                [1.66,1.70,1.74,1.78,1.80,1.82,1.83,1.84,1.85,1.86,1.87,1.88,1.89,1.90,1.92,1.94,1.96,2.0,2.04,2.08],
-                [1.66,1.70,1.74,1.78,1.80,1.82,1.83,1.84,1.85,1.86,1.87,1.88,1.89,1.90,1.92,1.94,1.96,2.0,2.04,2.08],]
-use_inv_mass_bins: false # use binning in invariant mass distribution, neglects inv_mass_bins (default: false)
-
-apply_btd_cuts: True # apply bdt cuts
-bkg_ml_cuts: [0.0008, 0.0008, 0.0008, 0.0008, 0.0008, 0.001, 0.001, 0.001, 0.002, 0.003, 0.005, 0.008, 0.008] # max probability for bkg, one for each pt bin
-sig_ml_cuts: [0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1]       # min probability for sig, one for each pt bin
-
-# ep/sp subevents
-detA: 'FT0c'
-detB: 'FV0a'
-detC: 'TPCtot'
-
-# fit options
-Dmeson: 'Dzero'
-FixSigma: 0
-Sigma: [0.018, 0.018, 0.020, 0.022, 0.024, 0.026, 0.028, 0.032, 0.032, 0.035, 0.040, 0.045, 0.05, 0.022]
-SigmaFile: ''
-SigmaMultFactor: 1.
-FixMean: 0
-MeanFile: ''
-       #    1-2  2-2.5  2.5-3  3-3.5  3.5-4  4-5   5-6   6-7   7-8   8-10  10-12  12-16  16-24  24-36
-NSigma4SB: [4,   4,     4,     4,     4,     4,    4,    4,    4,    4,    3,     3,     3,     3,     3,    3, 3, 3, 3, 3]
-MassMin: [ 1.72, 1.72,  1.72,  1.72,  1.72,  1.72, 1.72, 1.72, 1.72, 1.72, 1.68,  1.66,  1.66,  1.72,  1.68, 1.72, 1.70 ] 
-MassMax: [ 2.02, 2.02,  2.02,  2.02,  2.02,  2.02, 2.04, 2.04, 2.06, 2.06, 2.06,  2.08,  2.08,  2.06,  2.06, 2.00, 2.00, 2.00, 2.05, 2.00, 2.00, 2.00, 2.00 ]
-Rebin: [   4,    4,     4,     4,     4,     4,    4,    4,    4,    4,    8,     8,     8,     4,     6, 6, 6, 10, 10, 5, 5, 10, 5, 5]
-InclSecPeak: [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ]
-SigmaSecPeak: []
-SigmaFileSecPeak: ''
-SigmaMultFactorSecPeak: 1.
-FixSigmaToFirstPeak: 0
-UseLikelihood: 1
-BkgFunc: [ 'kExpo', 'kExpo', 'kExpo', 'kExpo', 'kExpo', 'kExpo', 'kExpo', 'kExpo', 'kExpo', 'kExpo', 'kExpo', 'kExpo', 'kExpo', 'kExpo', 'kExpo', 'kExpo', 'kExpo', 'kExpo', 'kExpo', 'kExpo', 'kExpo' ]
-SgnFunc: [ 'kGaus', 'kGaus', 'kGaus', 'kGaus', 'kGaus', 'kGaus', 'kGaus', 'kGaus', 'kGaus', 'kGaus', 'kGaus', 'kGaus', 'kGaus', 'kGaus', 'kGaus', 'kGaus', 'kGaus', 'kGaus', 'kGaus', 'kGaus', 'kGaus' ]
-BkgFuncVn: ['kLin', 'kLin', 'kLin', 'kLin', 'kLin', 'kLin', 'kLin', 'kLin', 'kLin', 'kLin', 'kLin', 'kLin', 'kLin', 'kLin', 'kLin', 'kLin', 'kLin', 'kLin', 'kLin', 'kLin', 'kLin' ]
-# only for D0
-# if `enableRef` is set to `true`,  and `ReflFile` is empty, then `ReflFile` will be aotumatically filled.
-enableRef: false #reflection for D0. 
-# if `ReflFile` is filled, then it will use the filled one
-reflFile: ''
-ReflFunc: "2gaus"
-FixSigmaRatio: 0 # used only if SgnFunc = k2GausSigmaRatioPar
-SigmaRatioFile: ""
-BoundMean: 0 # 0: Do not set limits on mean range, 1: the mean is set to be between MassMin[i] and MassMax[i]
-enableRef: false #reflection for D0. 
-ReflFile: ''
+# var names of axes to keep + rebin factors
+axestokeep: ['Mass', 'sp', 'score_FD', 'Pt', 'cent']
+RebinSparse:
+       Mass: 2
+       sp: 1
+       score_FD: 10
+       Pt: 1
+       cent: 1

--- a/run3/tool/pre_process.py
+++ b/run3/tool/pre_process.py
@@ -14,6 +14,9 @@ from ROOT import TFile
 import argparse
 import itertools
 import concurrent.futures
+script_dir = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(f"{script_dir}/../flow/")
+sys.path.append(f"{script_dir}/../flow/BDT")
 from flow_analysis_utils import get_centrality_bins
 from sparse_dicts import get_sparses
 
@@ -88,8 +91,8 @@ def pre_process(config, ptmins, ptmaxs, centmin, centmax, axestokeep, outputDir)
         processed_sparse.Write('hSparseFlowCharm')
         outFile.Close()
         
-        out_file.mkdir(f'Flow_{iPt}_ipt_{ptmin}_{ptmax}')
-        out_file.cd(f'Flow_{iPt}_ipt_{ptmin}_{ptmax}')
+        out_file.mkdir(f'Flow_pt_{ptmin}_{ptmax}')
+        out_file.cd(f'Flow_pt_{ptmin}_{ptmax}')
         for idim in range(processed_sparse.GetNdimensions()):
             histo = processed_sparse.Projection(idim)
             histo.SetName(processed_sparse.GetAxis(idim).GetName())

--- a/run3/tool/pre_process.py
+++ b/run3/tool/pre_process.py
@@ -30,19 +30,20 @@ def cook_thnsparse(thnsparse_list, ptmins, ptmaxs, axestokeep):
     Returns:
         - dict: Dictionary of projected THnSparse objects for each pT bin.
     '''
-    sparses = {}
-    for iThn, (sparse_key, sparse) in enumerate(thnsparse_list.items()):
+    thnsparses = {}
+    for iThn, thnsparse in enumerate(thnsparse_list):
+        #TODO: add possibility to apply cuts for different variables
         for iPt in range(0, len(ptmins)):
-            binMin = sparse.GetAxis(1).FindBin(ptmins[iPt]*1.00001)
-            binMax = sparse.GetAxis(1).FindBin(ptmaxs[iPt]*0.99999)
-            sparse.GetAxis(1).SetRange(binMin, binMax)
-            thn_proj = sparse.Projection(len(axestokeep), array.array('i', axestokeep), 'O')
+            binMin = thnsparse.GetAxis(1).FindBin(ptmins[iPt]*1.00001)
+            binMax = thnsparse.GetAxis(1).FindBin(ptmaxs[iPt]*0.99999)
+            thnsparse.GetAxis(1).SetRange(binMin, binMax)
+            thn_proj = thnsparse.Projection(len(axestokeep), array.array('i', axestokeep), 'O')
             
             if iThn == 0:
-                sparses[iPt] = thn_proj
+                thnsparses[iPt] = thn_proj
             else:
-                sparses[iPt].Add(thn_proj)
-    return sparses
+                thnsparses[iPt].Add(thn_proj)
+    return thnsparses
 
 def pre_process(config, ptmins, ptmaxs, centmin, centmax, axestokeep, outputDir):
     

--- a/run3/tool/pre_process.py
+++ b/run3/tool/pre_process.py
@@ -7,10 +7,17 @@ python3 pre_process.py config_pre.yml AnRes_1.root AnRes_2.root --pre --sigma
 import os
 import sys
 import yaml
+import numpy as np
 import array
 import ROOT
+from ROOT import TFile
 import argparse
+import itertools
 import concurrent.futures
+sys.path.append("/Users/mcosti/Analysis/DmesonAnalysis/run3/flow/BDT/")
+sys.path.append("/Users/mcosti/Analysis/DmesonAnalysis/run3/flow/")
+from flow_analysis_utils import get_centrality_bins
+from sparse_dicts import get_sparses
 
 def cook_thnsparse(thnsparse_list, ptmins, ptmaxs, axestokeep):
     '''
@@ -25,61 +32,80 @@ def cook_thnsparse(thnsparse_list, ptmins, ptmaxs, axestokeep):
     Returns:
         - dict: Dictionary of projected THnSparse objects for each pT bin.
     '''
-    thnsparses = {}
-    for iThn, thnsparse in enumerate(thnsparse_list):
-        #TODO: add possibility to apply cuts for different variables
+    sparses = {}
+    for iThn, (sparse_key, sparse) in enumerate(thnsparse_list.items()):
         for iPt in range(0, len(ptmins)):
-            binMin = thnsparse.GetAxis(1).FindBin(ptmins[iPt]*1.00001)
-            binMax = thnsparse.GetAxis(1).FindBin(ptmaxs[iPt]*0.99999)
-            thnsparse.GetAxis(1).SetRange(binMin, binMax)
-            thn_proj = thnsparse.Projection(len(axestokeep), array.array('i', axestokeep), 'O')
+            binMin = sparse.GetAxis(1).FindBin(ptmins[iPt]*1.00001)
+            binMax = sparse.GetAxis(1).FindBin(ptmaxs[iPt]*0.99999)
+            sparse.GetAxis(1).SetRange(binMin, binMax)
+            thn_proj = sparse.Projection(len(axestokeep), array.array('i', axestokeep), 'O')
             
             if iThn == 0:
-                thnsparses[iPt] = thn_proj
+                sparses[iPt] = thn_proj
             else:
-                thnsparses[iPt].Add(thn_proj)
-    return thnsparses
+                sparses[iPt].Add(thn_proj)
+    return sparses
 
-def pre_process(an_res_file, ptmins, ptmaxs, axestokeep, outputDir):
+def pre_process(config, ptmins, ptmaxs, centmin, centmax, axestokeep, outputDir):
     
     # Load the ThnSparse
-    thnsparse_list = []
-    for file in an_res_file:
-        infile = ROOT.TFile(file, 'READ')
-        thnsparse_list.append(infile.Get('hf-task-flow-charm-hadrons/hSparseFlowCharm'))
-        print(infile.GetName())
+    thnsparse_list, _, _, sparse_axes = get_sparses(config, True, False, False)
 
-    def process_pt_bin(iPt, ptmin, ptmax, thnsparse_list, axestokeep, outputDir):
-        pre_thnsparse = None
-        # add posibility to apply cuts for different variables
-        for iThn, thnsparse in enumerate(thnsparse_list):
-            binMin = thnsparse.GetAxis(1).FindBin(ptmin * 1.00001)
-            binMax = thnsparse.GetAxis(1).FindBin(ptmax * 0.99999)
-            thnsparse.GetAxis(1).SetRange(binMin, binMax)
-            
-            thn_proj = thnsparse.Projection(len(axestokeep), array.array('i', axestokeep), 'O')
-            thn_proj.SetName(thnsparse.GetName())
+    os.makedirs(f'{outputDir}/pre/AnRes', exist_ok=True)
+    out_file = TFile(f'{outputDir}/pre/AnRes/Projections_{centmin}_{centmax}_{ptmins}_{ptmaxs}.root', 'recreate')
+    for isparse, (key, sparse) in enumerate(thnsparse_list.items()):
+        if 'Flow' in key:
+            out_file.mkdir(f'Flow_{isparse}')
+            out_file.cd(f'Flow_{isparse}')
+            for idim in range(sparse.GetNdimensions()):
+                histo = sparse.Projection(idim)
+                histo.SetName(sparse.GetAxis(idim).GetName())
+                histo.SetTitle(sparse.GetAxis(idim).GetTitle())
+                histo.Write()
+        
+    def process_pt_bin(iPt, ptmin, ptmax, centmin, centmax, bkg_max_cut, thnsparse_list, axestokeep, outputDir):
+        print(f'Processing pT bin {ptmin} - {ptmax}, cent {centmin}-{centmax}')
+        # add possibility to apply cuts for different variables
+        for iThn, (sparse_key, sparse) in enumerate(thnsparse_list.items()):
+            cloned_sparse = sparse.Clone()
+            cloned_sparse.GetAxis(sparse_axes['Flow']['Pt']).SetRangeUser(ptmin, ptmax)
+            cloned_sparse.GetAxis(sparse_axes['Flow']['cent']).SetRangeUser(centmin, centmax)
+            cloned_sparse.GetAxis(sparse_axes['Flow']['score_bkg']).SetRangeUser(0, bkg_max_cut)
+            thn_proj = cloned_sparse.Projection(len(axestokeep), array.array('i', [sparse_axes['Flow'][axtokeep] for axtokeep in axestokeep]), 'O')
+            thn_proj.SetName(cloned_sparse.GetName())
             
             if iThn == 0:
-                pre_thnsparse = thn_proj.Clone()
+                processed_sparse = thn_proj.Clone()
             else:
-                pre_thnsparse.Add(thn_proj)
+                processed_sparse.Add(thn_proj)
         
-        os.makedirs(f'{outputDir}/pre/AnRes', exist_ok=True)
-        outFile = ROOT.TFile(f'{outputDir}/pre/AnRes/AnalysisResults_pt{iPt}.root', 'RECREATE')
+        if config.get('RebinSparse'):
+            rebin_factors = [config['RebinSparse'][axtokeep] for axtokeep in axestokeep]
+            processed_sparse = processed_sparse.Rebin(array.array('i', rebin_factors))
+        
+        outFile = ROOT.TFile(f'{outputDir}/pre/AnRes/AnalysisResults_pt_{int(ptmin*10)}_{int(ptmax*10)}.root', 'recreate')
         outFile.mkdir('hf-task-flow-charm-hadrons')
         outFile.cd('hf-task-flow-charm-hadrons')
-        pre_thnsparse.Write()
+        processed_sparse.Write('hSparseFlowCharm')
         outFile.Close()
         
-        del pre_thnsparse
+        out_file.mkdir(f'Flow_{iPt}_ipt_{ptmin}_{ptmax}')
+        out_file.cd(f'Flow_{iPt}_ipt_{ptmin}_{ptmax}')
+        for idim in range(processed_sparse.GetNdimensions()):
+            histo = processed_sparse.Projection(idim)
+            histo.SetName(processed_sparse.GetAxis(idim).GetName())
+            histo.SetTitle(processed_sparse.GetAxis(idim).GetTitle())
+            histo.Write()
+        
+        del processed_sparse
         
         print(f'Finished processing pT bin {ptmin} - {ptmax}')
 
+    bkg_maxs = config['bkg_cuts']
     # Loop over each pt bin in parallel
     max_workers = 6
     with concurrent.futures.ThreadPoolExecutor(max_workers) as executor:
-        tasks = [executor.submit(process_pt_bin, iPt, ptmin, ptmax, thnsparse_list, axestokeep, outputDir) for iPt, (ptmin, ptmax) in enumerate(zip(ptmins, ptmaxs))]
+        tasks = [executor.submit(process_pt_bin, iPt, ptmin, ptmax, centmin, centmax, bkg_maxs[iPt], thnsparse_list, axestokeep, outputDir) for iPt, (ptmin, ptmax) in enumerate(zip(ptmins, ptmaxs))]
         for task in concurrent.futures.as_completed(tasks):
             task.result()
         
@@ -111,11 +137,12 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Arguments")
     parser.add_argument('config_pre', metavar='text', 
                         default='config_pre.yml', help='configuration file')
-    parser.add_argument('an_res_file', metavar='text', 
-                        nargs='+', help='input ROOT files with anres')
+    parser.add_argument('--out_dir', metavar='text', default="", 
+                        help='output directory for projected .root files')
     parser.add_argument('--pre', action='store_true', help='pre-process the AnRes.root')
     parser.add_argument('--sigma', action='store_true', help='get the sigma')
     parser.add_argument('--skip_projection', '-sp', action='store_true', help='skip the projection')
+    parser.add_argument("--suffix", "-s", metavar="text", default="", help="suffix for output files")
     args = parser.parse_args()
 
     if not args.pre and not args.sigma:
@@ -129,10 +156,12 @@ if __name__ == "__main__":
     ptmins = config['ptmins']
     ptmaxs = config['ptmaxs']
     axestokeep = config['axestokeep']
-    outputDir = config['outputDir']
+    outputDir = args.out_dir if args.out_dir != "" else config['skim_out_dir'] 
+    
+    centMin, centMax = get_centrality_bins(config['centrality'])[1]
     
     if args.pre:
-        pre_process(args.an_res_file, ptmins, ptmaxs, axestokeep, outputDir)
+        pre_process(config, ptmins, ptmaxs, centMin, centMax, axestokeep, outputDir)
     
     if args.sigma:
         
@@ -142,7 +171,7 @@ if __name__ == "__main__":
         if os.path.exists(f'{outputDir}/pre'):
             preFiles = [f'{outputDir}/pre/AnRes/AnalysisResults_pt{iFile}.root' for iFile in range(len(ptmins))]
         else:
-            raise ValueError(f'No eff fodel found in {outputDir}')
+            raise ValueError(f'No eff folder found in {outputDir}')
         preFiles.sort()
         
         # you have to know the sigma from the differet prompt enhance samples is stable first

--- a/run3/tool/pre_process.py
+++ b/run3/tool/pre_process.py
@@ -14,8 +14,6 @@ from ROOT import TFile
 import argparse
 import itertools
 import concurrent.futures
-sys.path.append("/Users/mcosti/Analysis/DmesonAnalysis/run3/flow/BDT/")
-sys.path.append("/Users/mcosti/Analysis/DmesonAnalysis/run3/flow/")
 from flow_analysis_utils import get_centrality_bins
 from sparse_dicts import get_sparses
 


### PR DESCRIPTION
This PR introduces some modifications to the pre-processing of the `AnalysisResults.root` files obtained from grid. First, the possibility to rebin the sparse axes is introduced. Then, to clarify the scripts' logic, the script `sparse_dicts.py` is introduced to store the structure of the sparses for the different particles. By doing so, we can refer to variables when projecting sparses instead of numbers and the logic should be clearer. Moreover, the `.yml` script of the preprocess is cleaned of the entries regarding the fit procedure since I think the pre-process should be a standalone operation to perform only once. The preprocessed files are then stored in a configurable directory, from which the analysis chain can take them (to be implemented in the next PR).