### PR TITLE
Generalize flow cutvar code to all particle species

### DIFF
--- a/run3/flow/BDT/ComputeDataDriFrac_flow.py
+++ b/run3/flow/BDT/ComputeDataDriFrac_flow.py
@@ -7,7 +7,7 @@ import argparse
 import os
 import sys
 sys.path.append('../../../')
-from ROOT import TFile, TCanvas, TLegend, gROOT  # pylint: disable=import-error,no-name-in-module
+from ROOT import TFile, TCanvas, TLegend, gROOT, kRed, kBlue  # pylint: disable=import-error,no-name-in-module
 from utils.AnalysisUtils import GetPromptFDFractionCutSet
 from utils.StyleFormatter import SetGlobalStyle
 
@@ -101,14 +101,18 @@ def data_driven_frac(inputdir, outputdir, suffix, batch=False):
         ptMin = hPromptFrac.GetBinLowEdge(1)
         cFrac = TCanvas('cFrac', '', 800, 800)
         cFrac.DrawFrame(ptMin, 0., ptMax, 1.2, ';#it{p}_{T} (GeV/#it{c}); fraction')
+        hPromptFrac.SetLineColor(kRed)
         hPromptFrac.Draw('same')
+        hFDFrac.SetLineColor(kBlue)
         hFDFrac.Draw('same')
         legFrac.Draw()
         cFrac.Update()
 
         cFracCorrFrac = TCanvas('cFracCorrFrac', '', 800, 800)
         cFracCorrFrac.DrawFrame(ptMin, 0., ptMax, 1.2, ';#it{p}_{T} (GeV/#it{c}); corrected fraction')
+        hPromptFracCorr.SetLineColor(kRed)
         hPromptFracCorr.Draw('same')
+        hFDFracCorr.SetLineColor(kBlue)
         hFDFracCorr.Draw('same')
         legFrac.Draw()
         cFracCorrFrac.Update()
@@ -116,7 +120,9 @@ def data_driven_frac(inputdir, outputdir, suffix, batch=False):
         cEff = TCanvas('cEff', '', 800, 800)
         cEff.DrawFrame(ptMin, 1.e-4, ptMax, 1., ';#it{p}_{T} (GeV/#it{c}); (Acc#times#font[152]{e})')
         cEff.SetLogy()
+        hEffPrompt.SetLineColor(kRed)
         hEffPrompt.Draw('same')
+        hEffFD.SetLineColor(kBlue)
         hEffFD.Draw('same')
         legEff.Draw()
         cEff.Update()

--- a/run3/flow/BDT/ComputeV2vsFDFrac.py
+++ b/run3/flow/BDT/ComputeV2vsFDFrac.py
@@ -29,9 +29,11 @@ def set_frame_style(canv, Title, particleTit):
     hFrame.GetXaxis().SetTitleOffset(1.4)
     hFrame.GetYaxis().SetNdivisions(505)
 
-def v2_vs_frac(config_flow, inputdir, outputdir, suffix):
+def v2_vs_frac(config, inputdir, outputdir, suffix):
 
-    with open(config_flow, 'r') as ymlCfgFile:
+    CutSets, _, _, _, _ = get_cut_sets_config(config)
+    nCutSets = max(CutSets)
+    with open(config, 'r') as ymlCfgFile:
         config = yaml.load(ymlCfgFile, yaml.FullLoader)
         
     ptmins = config['ptmins']
@@ -45,8 +47,6 @@ def v2_vs_frac(config_flow, inputdir, outputdir, suffix):
 
     particleTit, _, decay, _ = get_particle_info(particleName)
     
-    CutSets, _, _, _, _ = get_cut_sets_config(config_flow)
-    nCutSets = max(CutSets)
 
     if os.path.exists(f'{inputdir}/DataDrivenFrac'):
         fracFiles = [f'{inputdir}/DataDrivenFrac/{file}'
@@ -108,7 +108,7 @@ def v2_vs_frac(config_flow, inputdir, outputdir, suffix):
         fracFDUnc = [hFracFD[i].GetBinError(iPt + 1) for i in range(nSets)]
 
         for iSet, (v2, fracFD, v2Unc, fracFDUnc) in enumerate(zip(v2Values, fracFDValues, v2Unc, fracFDUnc)):
-            print(f"pt: {ptCent:.2f}, v2: {v2:.2f}, fracFD: {fracFD:.2f}")
+            print(f"pt: {ptCent:.4f}, v2: {v2:.4f}, fracFD: {fracFD:.4f}")
             gFracVsV2[iPt].SetPoint(iSet, fracFD, v2)
             gFracVsV2[iPt].SetPointError(iSet, fracFDUnc, v2Unc)
         
@@ -126,15 +126,15 @@ def v2_vs_frac(config_flow, inputdir, outputdir, suffix):
 
         # get the v2 value at the FD fraction = 1, and it is not the last bin?
         hV2VsPtFD.SetBinContent(iPt + 1, 
-                                hV2VsFrac[-1].GetBinContent(hV2VsFrac[-1].FindBin(1.0) - 1))
+                                hV2VsFrac[-1].GetBinContent(hV2VsFrac[-1].GetNbinsX()))
         hV2VsPtFD.SetBinError(iPt + 1,
-                                hV2VsFrac[-1].GetBinError(hV2VsFrac[-1].FindBin(1.0) - 1))
+                                hV2VsFrac[-1].GetBinError(hV2VsFrac[-1].GetNbinsX()))
         
         # get the v2 value at the FD fraction = 0, and it is the first bin?
         hV2VsPtPrompt.SetBinContent(iPt + 1, 
-                                    hV2VsFrac[-1].GetBinContent(hV2VsFrac[-1].FindBin(0.0)))
+                                    hV2VsFrac[-1].GetBinContent(hV2VsFrac[-1].GetBin(1)))
         hV2VsPtPrompt.SetBinError(iPt + 1,
-                                    hV2VsFrac[-1].GetBinError(hV2VsFrac[-1].FindBin(0.0)))
+                                    hV2VsFrac[-1].GetBinError(hV2VsFrac[-1].GetBin(1)))
         
         #TODO: plot the v2 vs pt, and the center of the pt bin is calculate by the average of pT
 
@@ -151,7 +151,7 @@ def v2_vs_frac(config_flow, inputdir, outputdir, suffix):
     t.SetTextFont(42)
     t.SetTextColor(kBlack)
 
-    for iPt in range(nPtBins):
+    for iPt, (ptMin, ptMax) in enumerate(zip(ptmins, ptmaxs)):
         if iPt == 0:
             suffix_pdf = '('
         elif iPt == nPtBins-1:
@@ -173,22 +173,23 @@ def v2_vs_frac(config_flow, inputdir, outputdir, suffix):
         hV2VsFrac[iPt].Draw("same pZ")
         gFracVsV2[iPt].Draw("same pZ")
 
-        gFracVsV2[iPt].Write()
-        hV2VsFrac[iPt].Write()
-
         cFrac[-1].Update()
 
         cFrac[iPt].SaveAs(f"{outputdir}/V2VsFrac/FracV2_{suffix}.pdf{suffix_pdf}")
 
+        outFile.mkdir(f"pt_{int(ptMin*10)}_{int(ptMax*10)}")
+        outFile.cd(f"pt_{int(ptMin*10)}_{int(ptMax*10)}")
+        gFracVsV2[iPt].Write('gV2VsFrac')
+        hV2VsFrac[iPt].Write('hV2VsFrac')
+
+    outFile.cd()
     PtTit = "#it{p}_{T} GeV/#it{c}"
     leg = TLegend(0.55, 0.75, 0.88, 0.89)
     leg.SetTextSize(0.045)
     leg.SetBorderSize(0)
     leg.SetFillStyle(0)
-    SetObjectStyle(hV2VsPtFD, color=GetROOTColor("kAzure+4 "), fillstyle=1)
+    SetObjectStyle(hV2VsPtFD, color=GetROOTColor("kAzure+4"), fillstyle=1)
     SetObjectStyle(hV2VsPtPrompt, color=GetROOTColor("kRed+1"), fillstyle=1)
-    # SetObjectStyle(hV2VsPtFD, GetROOTColor("kAzure+4"), 1)
-    # SetObjectStyle(hV2VsPtPrompt, GetROOTColor("kRed+1"), 1)
 
     cV2VsPtFD = TCanvas("cV2VsPtFD", "non-prompt v2 versus pt")
     cV2VsPtFD.SetCanvasSize(800, 800)

--- a/run3/flow/BDT/compute_frac_cut_var.py
+++ b/run3/flow/BDT/compute_frac_cut_var.py
@@ -16,11 +16,13 @@ from flow_analysis_utils import get_cut_sets_config
 from utils.StyleFormatter import SetGlobalStyle, SetObjectStyle
 from utils.AnalysisUtils import GetPromptFDYieldsAnalyticMinimisation, ApplyVariationToList
 
-def compute_frac_cut_var(config_flow, inputdir, outputdir, suffix, batch=False):
+def compute_frac_cut_var(config, inputdir, outputdir, suffix, batch=False):
 
     gROOT.SetBatch(batch)
 
-    with open(config_flow, 'r') as ymlCfgFile:
+    CutSets, _, _, _, _ = get_cut_sets_config(config)
+    nCutSets = max(CutSets)
+    with open(config, 'r') as ymlCfgFile:
         config = yaml.load(ymlCfgFile, yaml.FullLoader)
 
     if os.path.exists(f'{inputdir}/eff'):
@@ -44,9 +46,6 @@ def compute_frac_cut_var(config_flow, inputdir, outputdir, suffix, batch=False):
     
     #TODO: apply smearing
 
-    histoNameRaw = config['histoNameRaw']
-    histoNameEffPrompt = config['histoNameEffPrompt']
-    histoNameEffFD = config['histoNameEffFD']
 
     # nSets = len(rawYieldFiles)
 
@@ -60,9 +59,6 @@ def compute_frac_cut_var(config_flow, inputdir, outputdir, suffix, batch=False):
     applyEffVarToFD = config['minimisation']['applyEffVariation']['feeddown']
 
     hRawYields, hEffPrompt, hEffFD = [], [], []
-    
-    CutSets, _, _, _, _ = get_cut_sets_config(config_flow)
-    nCutSets = max(CutSets)
 
     # load inputs raw yields and efficiencies
     hCrossSecPrompt, hCrossSecFD = [], []
@@ -70,12 +66,12 @@ def compute_frac_cut_var(config_flow, inputdir, outputdir, suffix, batch=False):
     for inFileNameRawYield, inFileNameEff in zip(rawYieldFiles, effFiles):
 
         inFileRawYield = ROOT.TFile.Open(inFileNameRawYield)
-        hRawYields.append(inFileRawYield.Get(histoNameRaw))
+        hRawYields.append(inFileRawYield.Get('hRawYieldsSimFit'))
         hRawYields[-1].SetDirectory(0)
         
         inFileEff = TFile.Open(inFileNameEff)
-        hEffPrompt.append(inFileEff.Get(histoNameEffPrompt))
-        hEffFD.append(inFileEff.Get(histoNameEffFD))
+        hEffPrompt.append(inFileEff.Get('hEffPrompt'))
+        hEffFD.append(inFileEff.Get('hEffFD'))
         hEffPrompt[-1].SetDirectory(0)
         hEffFD[-1].SetDirectory(0)
 
@@ -185,8 +181,8 @@ def compute_frac_cut_var(config_flow, inputdir, outputdir, suffix, batch=False):
             hCovCorrYields[covElem[0]][covElem[1]].SetBinContent(iPt+1, covMatrixCorrYields.item(covElem))
             hCovCorrYields[covElem[0]][covElem[1]].SetBinError(iPt+1, 0.)
 
-        ptString = f'pT{ptMin:.0f}_{ptMax:.0f}'
-        commonString = f'{ptMin:.0f} < #it{{p}}_{{T}} < {ptMax:.0f}  GeV/#it{{c}};cut set'
+        ptString = f'pT{ptMin:.1f}_{ptMax:.1f}'
+        commonString = f'{ptMin:.1f} < #it{{p}}_{{T}} < {ptMax:.1f}  GeV/#it{{c}};cut set'
         hRawYieldsVsCut.append(TH1F(f'hRawYieldsVsCutPt_{ptString}', f'{commonString};raw yield', nSets, 0.5, nSets + 0.5))
         hRawYieldsVsCutReSum.append(TH1F(f'hRawYieldsVsCutReSum_{ptString}', f'{commonString};raw yield',
                                         nSets, 0.5, nSets + 0.5))
@@ -351,7 +347,10 @@ def compute_frac_cut_var(config_flow, inputdir, outputdir, suffix, batch=False):
     hCorrYieldFD.Write()
     for covElem in product(range(2), range(2)):
         hCovCorrYields[covElem[0]][covElem[1]].Write()
-    for iPt in range(hRawYields[0].GetNbinsX()):
+    for iPt, (ptmin, ptmax) in enumerate(zip(ptmins, ptmaxs)):
+        outFile.mkdir(f"pt{ptmin:.1f}_{ptmax:.1f}")
+        outFile.cd(f"pt{ptmin:.1f}_{ptmax:.1f}")
+        print(f"Writing to dir pt{ptmin:.1f}_{ptmax:.1f} of file {outFile}")
         cDistr[iPt].Write()
         cEff[iPt].Write()
         cFrac[iPt].Write()
@@ -372,7 +371,7 @@ def compute_frac_cut_var(config_flow, inputdir, outputdir, suffix, batch=False):
     outFileNameDistrPDF = outFileName.replace('.root', '_Distr.pdf')
     outFileNameFracPDF = outFileName.replace('.root', '_Frac.pdf')
     outFileNameCorrMatrixPDF = outFileName.replace('.root', '_CorrMatrix.pdf')
-    for iPt in range(hRawYields[0].GetNbinsX()):
+    for iPt in range(len(ptmins)):
         if iPt == 0:
             cEff[iPt].SaveAs(f'{outFileNameEffPDF}[')
             cDistr[iPt].SaveAs(f'{outFileNameDistrPDF}[')

--- a/run3/flow/BDT/make_yaml_for_ml.py
+++ b/run3/flow/BDT/make_yaml_for_ml.py
@@ -11,14 +11,12 @@ import sys
 sys.path.append('..')
 from flow_analysis_utils import get_cut_sets_config
 
-def make_combination(mass_axis, pt_axis, bkg_axis, sig_axis, ptmins, ptmaxs, nCutSets,
-                     sig_cut_lower_file, sig_cut_upper_file, bkg_cut_lower_file, bkg_cut_upper_file):
+def make_combination(ptmins, ptmaxs, nCutSets, sig_cut_lower_file, 
+                     sig_cut_upper_file, bkg_cut_lower_file, bkg_cut_upper_file):
     '''
     Create a dictionary with the combination of cuts for each cutset
 
     Parameters:
-    mass_axis: int
-        axis number for the invariant mass
     pt_axis: int
         axis number for the pt
     bkg_axis: int
@@ -43,27 +41,20 @@ def make_combination(mass_axis, pt_axis, bkg_axis, sig_axis, ptmins, ptmaxs, nCu
         combinations[iFile] = {
             'icutset': iFile,
             'cutvars': {
-                'InvMass': {
-                    'axisnum': mass_axis,
-                    'name': 'inv_mass'
-                },
                 'Pt': {
-                    'axisnum': pt_axis,
                     'min': [i for i in ptmins],
                     'max': [j for j in ptmaxs],
                     'name': 'pt_cand'
                 },
-                'ML_output_Bkg': {
-                    'axisnum': bkg_axis,
+                'score_bkg': {
                     'min': [float(i) for i in bkg_cut_lower_file[iFile]],
                     'max': [float(j) for j in bkg_cut_upper_file[iFile]],
-                    'name': 'ML_output_Bkg'
+                    'name': 'score_bkg'
                 },
-                'ML_output_FD': {
-                    'axisnum': sig_axis,
+                'score_FD': {
                     'min': [float(i) for i in sig_cut_lower_file[iFile]],
                     'max': [float(j) for j in sig_cut_upper_file[iFile]],
-                    'name': 'ML_output_FD'
+                    'name': 'score_FD'
                 }
             }
         }
@@ -76,24 +67,24 @@ def make_yaml(flow_config, outputdir, suffix):
     os.makedirs(outputdir, exist_ok=True)
 
     # load the variable from the input config
-    # axis
-    axis = input['axes_mc']
-    mass_axis = axis['mass']
-    pt_axis = axis['pt']
-    bkg_axis = axis['bdt_bkg']
-    sig_axis = axis['bdt_sig']
 
     # pt
     ptmins = input['ptmins']
     ptmaxs = input['ptmaxs']
 
-    ## safely check
+    ## safety check
     if len(ptmins) != len(ptmaxs):
         raise ValueError(f'''The number of pt bins({len(ptmins)}, {len(ptmaxs)} are not the same''')
 
     nCutSets, sig_cut_lower, sig_cut_upper, bkg_cut_lower, bkg_cut_upper = get_cut_sets_config(flow_config)
+    # print(f"sig_cut_lower: {sig_cut_lower}")
+    # print(f"sig_cut_upper: {sig_cut_upper}")
+    # print(f"bkg_cut_lower: {bkg_cut_lower}")
+    # print(f"bkg_cut_upper: {bkg_cut_upper}")
     
     maxCutSets = max(nCutSets)
+    # print(f"nCutSets: {nCutSets}")
+    # print(f"maxCutSets: {maxCutSets}")
     sig_cut_lower_file, sig_cut_upper_file, bkg_cut_lower_file, bkg_cut_upper_file = {}, {}, {}, {}
     for iCut in range(maxCutSets):
         sig_cut_lower_file[iCut], sig_cut_upper_file[iCut], bkg_cut_lower_file[iCut], bkg_cut_upper_file[iCut] = [], [], [], []
@@ -110,15 +101,22 @@ def make_yaml(flow_config, outputdir, suffix):
                 bkg_cut_lower_file[iCut].append(bkg_cut_lower[iPt][nCutSets[iPt]-1])
                 bkg_cut_upper_file[iCut].append(bkg_cut_upper[iPt][nCutSets[iPt]-1])
 
-    combinations = make_combination(mass_axis, pt_axis, bkg_axis, sig_axis, ptmins, ptmaxs, maxCutSets,
-                                    sig_cut_lower_file, sig_cut_upper_file, bkg_cut_lower_file, bkg_cut_upper_file)
+    # print(f"sig_cut_lower_file: {sig_cut_lower_file}")
+    # print(f"sig_cut_upper_file: {sig_cut_upper_file}")
+    # print(f"bkg_cut_lower_file: {bkg_cut_lower_file}")
+    # print(f"bkg_cut_upper_file: {bkg_cut_upper_file}")
+    # sig_cut_lower_file = {i: [sig_cut_lower[ipt][i] for ipt in range(len(ptmins))] for i in range(0, maxCutSets-1)}
+    # sig_cut_upper_file = {i: [sig_cut_upper[ipt][i] for ipt in range(len(ptmins))] for i in range(0, maxCutSets-1)}
+    # bkg_cut_lower_file = {i: [bkg_cut_lower[ipt][i] for ipt in range(len(ptmins))] for i in range(0, maxCutSets-1)}
+    # bkg_cut_upper_file = {i: [bkg_cut_upper[ipt][i] for ipt in range(len(ptmins))] for i in range(0, maxCutSets-1)}
 
-    print(f'''
-The axis number for the invariant mass is {mass_axis}
-The axis number for the pt is {pt_axis}
-The axis number for the bkg output is {bkg_axis}
-The axis number for the signal output is {sig_axis}
-''')
+    # print(f"sig_cut_lower_file: {sig_cut_lower_file}")
+    # print(f"sig_cut_upper_file: {sig_cut_upper_file}")
+    # print(f"bkg_cut_lower_file: {bkg_cut_lower_file}")
+    # print(f"bkg_cut_upper_file: {bkg_cut_upper_file}")
+    combinations = make_combination(ptmins, ptmaxs, maxCutSets, sig_cut_lower_file, 
+                                    sig_cut_upper_file, bkg_cut_lower_file, bkg_cut_upper_file)
+
     for iFile in range(maxCutSets):
         print(f'''For cutset {iFile}:
         ptmin: {ptmins}
@@ -138,10 +136,9 @@ The axis number for the signal output is {sig_axis}
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='Arguments')
     parser.add_argument('flow_config', metavar='text', default='config_flow.yml')
+    parser.add_argument('--preprocessed', action='store_true', help='Flag to indicate preprocessing of the sparses')
     parser.add_argument("--outputdir", "-o", metavar="text", default=".", help="output directory")
     parser.add_argument("--suffix", "-s", metavar="text", default="", help="suffix for output files")
     args = parser.parse_args()
 
-    make_yaml(args.flow_config,
-                args.outputdir,
-                args.suffix)
+    make_yaml(args.flow_config, args.outputdir, args.suffix)

--- a/run3/flow/BDT/proj_thn_mc.py
+++ b/run3/flow/BDT/proj_thn_mc.py
@@ -1,8 +1,8 @@
 '''
 Script to project the MC distributions and apply the pt weights from the AnRes.root of Dtask
 python3 proj_thn_mc.py config_flow.yml config_cutset.yml -o path/to/output -s text
-                                                        --ptweights path/to/file histName 
-                                                        --ptweightsB path/to/file histName
+                                                        --ptWeights path/to/file histName 
+                                                        --ptWeightsB path/to/file histName
 '''
 import ROOT
 import uproot
@@ -10,392 +10,283 @@ import yaml
 import argparse
 import sys
 import os
-from ROOT import gROOT
+from ROOT import gROOT, TFile
 from alive_progress import alive_bar
 from scipy.interpolate import InterpolatedUnivariateSpline
+from sparse_dicts import get_sparses 
+sys.path.append('..')
+from flow_analysis_utils import get_vn_versus_mass, get_centrality_bins
+
+### please fill your path of DmesonAnalysis
 sys.path.append('../../..')
-from utils.TaskFileLoader import LoadSparseFromTask
 
+def proj_data(sparse_flow, ptMin, ptMax, axes, inv_mass_bins, reso):
 
+    if isinstance(sparse_flow, dict):
+        for isparse, (key, sparse) in enumerate(sparse_flow.items()):
+            hist_mass_temp = sparse.Projection(axes['Flow']['Mass'])
+            hist_mass_temp.SetName(f'hist_mass_proj_{isparse}')
+            hist_mass_temp.SetDirectory(0)
 
-def proj_MC(config, cutsetConfig, ptweights, ptweightsB, outputdir, suffix):
+            if isparse == 0:
+                hist_mass = hist_mass_temp.Clone('hist_mass_proj')
+                hist_mass.SetDirectory(0)
+                hist_mass.Reset()
 
-    with open(config, 'r') as ymlCfgFile:
-        config = yaml.load(ymlCfgFile, yaml.FullLoader)
+            hist_mass.Add(hist_mass_temp)
 
-    # read configuration
-    inputFiles = config['MC_filename']
-    if not isinstance(inputFiles, list):
-        inputFiles = [inputFiles]
-    particleName = config['Dmeson']
-    enableRef = config['enableRef']
-    enableSecPeak = config['enableSecPeak']
-    Bspeciesweights = config['Bspeciesweights'] if 'Bspeciesweights' in config else None
+        hist_vn_sp = get_vn_versus_mass(list(sparse_flow.values()), inv_mass_bins, axes['Flow']['Mass'], axes['Flow']['sp'])
+        hist_vn_sp.SetDirectory(0)
+        if reso > 0:
+            hist_vn_sp.Scale(1./reso)
+    else:
+        hist_mass = sparse_flow.Projection(axes['Flow']['Mass'])
+        hist_vn_sp = get_vn_versus_mass(sparse_flow, inv_mass_bins, axes['Flow']['Mass'], axes['Flow']['sp'])
+        hist_vn_sp.SetDirectory(0)
+        if reso > 0:
+            hist_vn_sp.Scale(1./reso)
 
-    #TODO: safety checks for Dmeson reflecton and secondary peak
+    hist_mass.Write(f'hist_mass_proj_pt{int(ptMin*10)}_{int(ptMax*10)}')
+    hist_vn_sp.Write(f'hist_vn_sp_proj_pt{int(ptMin*10)}_{int(ptMax*10)}')
 
-    # check the arguments
-    if ptweights == []:
-        print('\033[91m WARNING: pt weights will not be provided! \033[0m')
-        ptweights = None
-    if ptweightsB == []:
-        print('\033[91m WARNING: B weights will not not be provided! \033[0m')
-        ptweightsB = None
-    if Bspeciesweights == None:
-        print('\033[91m WARNING: B species weights will not be provided! \033[0m')
+def proj_mc_reco(config, ptWeights, ptWeightsB, Bspeciesweights, sPtWeights, sPtWeightsB):
+    
+    ### project mass
+    if 'RecoAll' in sparsesReco:
+        hMass = sparsesReco['RecoAll'].Projection(axes['RecoAll']['Mass'])
+        hPt = sparsesReco['RecoAll'].Projection(axes['RecoAll']['Pt'])
 
-    # load thnsparse
-    for iFile, inputFile in enumerate(inputFiles):
-        if iFile == 0:
-            sparseReco, sparseGen = LoadSparseFromTask(inputFile, config, True)
-        else:
-            sparseRecoPart, sparseGenPart = LoadSparseFromTask(inputFile, config, True)
-            for sparsetype in sparseRecoPart:
-                sparseReco[sparsetype].Add(sparseRecoPart[sparsetype])
-            for sparsetype in sparseGenPart:
-                sparseGen[sparsetype].Add(sparseGenPart[sparsetype])
+    hMassPrompt = sparsesReco['RecoPrompt'].Projection(axes['RecoPrompt']['Mass'])
+    hMassFD = sparsesReco['RecoFD'].Projection(axes['RecoFD']['Mass'])    
 
-    refSparse = 'RecoPrompt'
+    ### project pt
+    hPtRefl, hPtReflPrompt, hPtReflFD, hPtPrompt, hPtFD = None, None, None, None, None
 
-    # compute the pt weights
-    if ptweights:
+    ### no pt weights
+    if not ptWeights and not ptWeightsB:
+        hPtPrompt = sparsesReco['RecoPrompt'].Projection(axes['RecoPrompt']['Pt'])
+        hPtFD = sparsesReco['RecoFD'].Projection(axes['RecoFD']['Pt'])
+
+    ### pt weights for prompt
+    if ptWeights:
+        hPtPrompt = sparsesReco['RecoPrompt'].Projection(axes['RecoPrompt']['Pt'])
+        for iBin in range(1, hPtPrompt.GetNbinsX()+1):
+            if hPtPrompt.GetBinContent(iBin) > 0.:
+                relStatUnc = hPtPrompt.GetBinError(iBin) / hPtPrompt.GetBinContent(iBin)
+                ptCent = hPtPrompt.GetBinCenter(iBin)
+                hPtPrompt.SetBinContent(iBin, hPtPrompt.GetBinContent(iBin) * sPtWeights(ptCent))
+                hPtPrompt.SetBinError(iBin, hPtPrompt.GetBinContent(iBin) * relStatUnc)
+        ### initially use prompt weights for FD, eventually overwrite
+        hPtFD = sparsesReco['RecoFD'].Projection(axes['RecoFD']['Pt'])
+        for iBin in range(1, hPtFD.GetNbinsX()+1):
+            if hPtFD.GetBinContent(iBin) > 0.:
+                relStatUnc = hPtFD.GetBinError(iBin) / hPtFD.GetBinContent(iBin)
+                ptCent = hPtFD.GetBinCenter(iBin)
+                hPtFD.SetBinContent(iBin, hPtFD.GetBinContent(iBin) * sPtWeights(ptCent))
+                hPtFD.SetBinError(iBin, hPtFD.GetBinContent(iBin) * relStatUnc)
+    ### pt weights for non-prompt, but no B species weights
+    if ptWeightsB and not Bspeciesweights:
+        hPtBvsPtD = sparsesReco['RecoFD'].Projection(axes['RecoFD']['Pt'], axes['RecoFD']['pt_bmoth'])
+        for iPtD in range(1, hPtBvsPtD.GetXaxis().GetNbins()+1):
+            for iPtB in range(1, hPtBvsPtD.GetYaxis().GetNbins()+1):
+                ptCentB = hPtBvsPtD.GetYaxis().GetBinCenter(iPtB)
+                origContent = hPtBvsPtD.GetBinContent(iPtD, iPtB)
+                origError = hPtBvsPtD.GetBinError(iPtD, iPtB)
+                weight = 0
+                if sPtWeightsB(ptCentB) > 0:
+                    weight = sPtWeightsB(ptCentB)
+                content = origContent * weight
+                error = 0
+                if origContent > 0:
+                    error = origError / origContent * content
+                hPtBvsPtD.SetBinContent(iPtD, iPtB, content)
+                hPtBvsPtD.SetBinError(iPtD, iPtB, error)
+        hPtFD = hPtBvsPtD.ProjectionX(f'hFDPt', 0, hPtBvsPtD.GetYaxis().GetNbins()+1, 'e')
+    ### pt weights from B for non-prompt and B species weights
+    elif ptWeightsB and Bspeciesweights:
+        hPtBvsBspecievsPtD = sparsesReco['RecoFD'].Projection(axes['RecoFD']['Pt'], axes['RecoFD']['flag_bhad'], axes['RecoFD']['pt_bmoth'])
+        for iPtD in range(1, hPtBvsBspecievsPtD.GetXaxis().GetNbins()+1):
+            for iBspecie in range(1, hPtBvsBspecievsPtD.GetYaxis().GetNbins()+1):
+                for iPtB in range(1, hPtBvsBspecievsPtD.GetZaxis().GetNbins()+1):
+                    ptCentB = hPtBvsBspecievsPtD.GetZaxis().GetBinCenter(iPtB)
+                    origContent = hPtBvsBspecievsPtD.GetBinContent(iPtD, iBspecie, iPtB)
+                    origError = hPtBvsBspecievsPtD.GetBinError(iPtD, iBspecie, iPtB)
+                    weight = Bspeciesweights[iBspecie-1]
+                    if sPtWeightsB(ptCentB) > 0:
+                        weight *= sPtWeightsB(ptCentB)
+                    content = origContent * weight
+                    error = 0
+                    if origContent > 0:
+                        error = origError / origContent * content
+                    hPtBvsBspecievsPtD.SetBinContent(iPtD, iBspecie, iPtB, content)
+                    hPtBvsBspecievsPtD.SetBinError(iPtD, iBspecie, iPtB, error)
+        hPtFD = hPtBvsBspecievsPtD.ProjectionX(f'hFDPt', 0, hPtBvsBspecievsPtD.GetYaxis().GetNbins()+1,
+                                                0, hPtBvsBspecievsPtD.GetZaxis().GetNbins()+1, 'e')
+    ### only B species weights
+    elif Bspeciesweights:
+        hBspecievsPtD = sparsesReco['RecoFD'].Projection(axes['RecoFD']['Pt'], axes['RecoFD']['flag_bhad'])
+        for iPtD in range(1, hBspecievsPtD.GetXaxis().GetNbins()+1):
+            for iBspecie in range(1, hBspecievsPtD.GetYaxis().GetNbins()+1):
+                origContent = hBspecievsPtD.GetBinContent(iPtD, iBspecie)
+                origError = hBspecievsPtD.GetBinError(iPtD, iBspecie)
+                weight = Bspeciesweights[iBspecie-1]
+                content = origContent * weight
+                error = 0
+                if origContent > 0:
+                    error = origError / origContent * content
+                hBspecievsPtD.SetBinContent(iPtD, iBspecie, content)
+                hBspecievsPtD.SetBinError(iPtD, iBspecie, error)
+        hPtFD = hBspecievsPtD.ProjectionX(f'hFDPt', 0, hBspecievsPtD.GetYaxis().GetNbins()+1, 'e')
+
+    ## write the output      
+    hMassPrompt.Write(f'hPromptMass')
+    hMassFD.Write(f'hFDMass')
+    hPtPrompt.Write(f'hPromptPt')
+    hPtFD.Write(f'hFDPt')
+
+    if 'RecoAll' in sparsesReco:
+        hMass.Write(f'hRecoAllMass')
+        hPt.Write(f'RecoAllPt')
+    if config.get('enableRef'):
+        hMassRefl = sparsesReco['RecoRefl'].Projection(axes['RecoRefl']['Mass'])
+        hMassRefl.Write(f'hReflMass')
+        hMassReflPrompt = sparsesReco['RecoReflPrompt'].Projection(axes['RecoReflPrompt']['Mass'])
+        hMassReflPrompt.Write(f'hReflPromptMass')
+        hMassReflFD = sparsesReco['RecoReflFD'].Projection(axes['RecoReflFD']['Mass'])
+        hMassReflFD.Write(f'hReflFDMass')
+        hPtRefl = sparsesReco['RecoRefl'].Projection(axes['RecoRefl']['Pt'])
+        hPtRefl.Write(f'hReflPt')
+        hPtReflPrompt = sparsesReco['RecoReflPrompt'].Projection(axes['RecoReflPrompt']['Pt'])
+        hPtReflPrompt.Write(f'hReflPromptPt')
+        hPtReflFD = sparsesReco['RecoReflFD'].Projection(axes['RecoReflFD']['Pt'])
+        hPtReflFD.Write(f'hReflFDPt')
+    if config.get('enableSecPeak'):
+        hMassPromptSecPeak = sparsesReco['RecoSecPeakPrompt'].Projection(axes['RecoSecPeakPrompt']['Mass'])
+        hMassPromptSecPeak.Write(f'hPromptSecPeakMass')
+        hMassFDSecPeak = sparsesReco['RecoSecPeakFD'].Projection(axes['RecoSecPeakFD']['Mass'])
+        hMassFDSecPeak.Write(f'hFDSecPeakMass')
+        hPtPromptSecPeak = sparsesReco['RecoSecPeakPrompt'].Projection(axes['RecoSecPeakPrompt']['Pt'])
+        hPtPromptSecPeak.Write(f'hPromptSecPeakPt')
+        hPtFDSecPeak = sparsesReco['RecoSecPeakFD'].Projection(axes['RecoSecPeakFD']['Pt'])
+        hPtFDSecPeak.Write(f'hFDSecPeakPt')
+
+def proj_mc_gen(config, ptWeights, ptWeightsB, Bspeciesweights, sPtWeights, sPtWeightsB):
+
+    if config.get('enableSecPeak'):
+        hGenPtPromptSecPeak = sparsesGen['GenSecPeakPrompt'].Projection(axes['GenSecPeakPrompt']['Pt'])
+        hGenPtPromptSecPeak.Write(f'hPromptSecPeakGenPt')
+        hGenPtFDSecPeak = sparsesGen['GenSecPeakFD'].Projection(axes['GenSecPeakFD']['Pt'])
+        hGenPtFDSecPeak.Write(f'hFDSecPeakGenPt')
+
+    ## no pt weights
+    # if not ptWeights and not ptWeightsB:
+    #     print('NO PT WEIGHTS FOR GENERATED')
+    #     hGenPtPrompt = sparsesGen['GenPrompt'].Projection(axes['GenPrompt']['Pt'])
+    #     # hGenPtFD = sparsesGen['GenFD'].Projection(axes['GenFD']['Pt'])
+
+    ## apply pt weights for prompt
+    if ptWeights:
+        hGenPtPrompt = sparsesGen['GenPrompt'].Projection(axes['GenPrompt']['Pt'])
+        for iBin in range(1, hGenPtPrompt.GetNbinsX()+1):
+            if hGenPtPrompt.GetBinContent(iBin) > 0:
+                relStatUnc = hGenPtPrompt.GetBinError(iBin) / hGenPtPrompt.GetBinContent(iBin)
+                ptCent = hGenPtPrompt.GetBinCenter(iBin)
+                hGenPtPrompt.SetBinContent(iBin, hGenPtPrompt.GetBinContent(iBin) * sPtWeights(ptCent))
+                hGenPtPrompt.SetBinError(iBin, hGenPtPrompt.GetBinContent(iBin) * relStatUnc)
+    else:
+        hGenPtPrompt = sparsesGen['GenPrompt'].Projection(axes['GenPrompt']['Pt'])
+
+    ## apply pt weights for non-prompt
+    ### pt weights from B for non-prompt, but no B species weights
+    if ptWeightsB and not Bspeciesweights:
+        hPtBvsPtGenD = sparsesGen['GenFD'].Projection(axes['GenFD']['Pt'], axes['GenFD']['pt_bmoth'])
+        for iPtD in range(1, hPtBvsPtGenD.GetXaxis().GetNbins()+1):
+            for iPtB in range(1, hPtBvsPtGenD.GetYaxis().GetNbins()+1):
+                ptCentB = hPtBvsPtGenD.GetYaxis().GetBinCenter(iPtB)
+                origContent = hPtBvsPtGenD.GetBinContent(iPtD, iPtB)
+                origError = hPtBvsPtGenD.GetBinError(iPtD, iPtB)
+                weight = 0
+                if sPtWeightsB(ptCent) > 0:
+                    weight = sPtWeightsB(ptCentB)
+                content = hPtBvsPtGenD.GetBinContent(iPtD, iPtB) * weight
+                error = 0
+                if origContent > 0:
+                    error = origError / origContent * content
+                hPtBvsPtGenD.SetBinContent(iPtD, iPtB, content)
+                hPtBvsPtGenD.SetBinError(iPtD, iPtB, error)
+        hGenPtFD = hPtBvsPtGenD.ProjectionX(f'hFDGenPt', 0, hPtBvsPtGenD.GetYaxis().GetNbins()+1, 'e')
+    ### pt weights from B for non-prompt and B species weights
+    elif ptWeightsB and Bspeciesweights:
+        hPtBvsBspecievsPtGenD = sparsesGen['GenFD'].Projection(axes['GenFD']['Pt'], axes['GenFD']['flag_bhad'], axes['GenFD']['pt_bmoth'])
+        for iPtD in range(1, hPtBvsBspecievsPtGenD.GetXaxis().GetNbins()+1):
+            for iBspecie in range(1, hPtBvsBspecievsPtGenD.GetYaxis().GetNbins()+1):
+                for iPtB in range(1, hPtBvsBspecievsPtGenD.GetZaxis().GetNbins()+1):
+                    ptCentB = hPtBvsBspecievsPtGenD.GetZaxis().GetBinCenter(iPtB)
+                    origContent = hPtBvsBspecievsPtGenD.GetBinContent(iPtD, iBspecie, iPtB)
+                    origError = hPtBvsBspecievsPtGenD.GetBinError(iPtD, iBspecie, iPtB)
+                    weight = Bspeciesweights[iBspecie-1]
+                    if sPtWeightsB(ptCentB) > 0:
+                        weight *= sPtWeightsB(ptCentB)
+                    content = origContent * weight
+                    error = 0
+                    if origContent > 0:
+                        error = origError / origContent * content
+                    hPtBvsBspecievsPtGenD.SetBinContent(iPtD, iBspecie, iPtB, content)
+                    hPtBvsBspecievsPtGenD.SetBinError(iPtD, iBspecie, iPtB, error)
+        hGenPtFD = hPtBvsBspecievsPtGenD.ProjectionX(f'hFDGenPt', 0, hPtBvsBspecievsPtGenD.GetYaxis().GetNbins()+1,
+                                                     0, hPtBvsBspecievsPtGenD.GetZaxis().GetNbins()+1, 'e')
+    ### only B species weights
+    elif Bspeciesweights:
+        hBspecievsPtGenD = sparsesGen['GenFD'].Projection(axes['GenFD']['Pt'], axes['GenFD']['flag_bhad'])
+        for iPtD in range(1, hBspecievsPtGenD.GetXaxis().GetNbins()+1):
+            for iBspecie in range(1, hBspecievsPtGenD.GetYaxis().GetNbins()+1):
+                origContent = hBspecievsPtGenD.GetBinContent(iPtD, iBspecie)
+                origError = hBspecievsPtGenD.GetBinError(iPtD, iBspecie)
+                weight = Bspeciesweights[iBspecie-1]
+                content = origContent * weight
+                error = 0
+                if origContent > 0:
+                    error = origError / origContent * content
+                hBspecievsPtGenD.SetBinContent(iPtD, iBspecie, content)
+                hBspecievsPtGenD.SetBinError(iPtD, iBspecie, error)
+        hGenPtFD = hBspecievsPtGenD.ProjectionX(f'hFDGenPt', 0, hBspecievsPtGenD.GetYaxis().GetNbins()+1, 'e')
+    ### no pt weights for generated FD
+    else:
+        hGenPtFD = sparsesGen['GenFD'].Projection(axes['GenFD']['Pt'])
+                            
+    ## write the output
+    hGenPtPrompt.Write(f'hPromptGenPt')
+    hGenPtFD.Write(f'hFDGenPt')
+
+def pt_weights_info(ptweights, ptweightsB):
+    # compute info for pt weights
+    if ptweights != []:
         ptWeights = uproot.open(ptweights[0])[ptweights[1]]
         bins = ptWeights.axis(0).edges()
         ptCentW = [(bins[iBin]+bins[iBin+1])/2 for iBin in range(len(bins)-1)]
         sPtWeights = InterpolatedUnivariateSpline(ptCentW, ptWeights.values())
+    else:
+        print('\033[91m WARNING: pt weights will not be provided! \033[0m')
+        ptWeights = None
+        sPtWeights = None
 
-    if ptweightsB:
+    if ptweightsB != []:
         ptWeightsB = uproot.open(ptweightsB[0])[ptweightsB[1]]
         bins = ptWeightsB.axis(0).edges()
         ptCentWB = [(bins[iBin]+bins[iBin+1])/2 for iBin in range(len(bins)-1)]
         sPtWeightsB = InterpolatedUnivariateSpline(ptCentWB, ptWeightsB.values())
+    else:
+        print('\033[91m WARNING: B weights will not not be provided! \033[0m')
+        ptWeightsB = None
+        sPtWeightsB = None
 
-    with open(cutsetConfig, 'r') as ymlCutSetFile:
-        cutSetCfg = yaml.load(ymlCutSetFile, yaml.FullLoader)
-    cutVars = cutSetCfg['cutvars']
-
-    # dictionaris of TH1
-    all_dict = {'InvMass': [], 'Pt': []}
-    prompt_dict = {'InvMass': [], 'Pt': []}
-    fd_dict = {'InvMass': [], 'Pt': []}
-    prompt_gen_list = []
-    fd_gen_list = []
-    refl_dict = {'InvMass': [], 'Pt': []}
-    prompt_dict_secpeak = {'InvMass': [], 'Pt': []}
-    fd_dict_secpeak = {'InvMass': [], 'Pt': []}
-    prompt_gen_list_secpeak = []
-    fd_gen_list_secpeak = []
+    if config.get('Bspeciesweights'):
+        Bspeciesweights = config['Bspeciesweights']
+    else:
+        print('\033[91m WARNING: B species weights will not be provided! \033[0m')
+        Bspeciesweights = None
     
-    # output file
-    os.makedirs(f'{outputdir}/proj_mc', exist_ok=True)
-    outfile = ROOT.TFile(f'{outputdir}/proj_mc/proj_mc_{suffix}.root', 'recreate')
-
-    with alive_bar(len(cutVars['Pt']['min']), title='Processing pT bins') as bar:
-        for iPt, (ptMin, ptMax) in enumerate(zip(cutVars['Pt']['min'], cutVars['Pt']['max'])):
-            print(f'Projecting distributions for {ptMin:.1f} < pT < {ptMax:.1f} GeV/c')
-            ptLowLabel = ptMin * 10
-            ptHighLabel = ptMax * 10
-
-            # apply pt weights for reconstruction level
-            ## apply cuts
-            for iVar in cutVars:
-                if iVar == 'InvMass':
-                    continue
-                axisNum = cutVars[iVar]['axisnum']
-                binMin = sparseReco[refSparse].GetAxis(axisNum).FindBin(cutVars[iVar]['min'][iPt] * 1.0001)
-                binMax = sparseReco[refSparse].GetAxis(axisNum).FindBin(cutVars[iVar]['max'][iPt] * 0.9999)
-
-                if iVar == 'ML_output_FD' or iVar == 'ML_output_Bkg':
-                    print(f'{iVar}: {cutVars[iVar]["min"][iPt]} < {iVar} < {cutVars[iVar]["max"][iPt]}')
-
-                if 'RecoAll' in sparseReco:
-                    sparseReco['RecoAll'].GetAxis(axisNum).SetRange(binMin, binMax)
-
-                if particleName == 'Dzero':
-                    sparseReco['RecoPrompt'].GetAxis(8).SetRange(2, 2) # make sure it is prompt
-                    sparseReco['RecoFD'].GetAxis(8).SetRange(3, 3)  # make sure it is non-prompt
-                    sparseReco['RecoPrompt'].GetAxis(6).SetRange(1, 2)  # make sure it is signal
-                    sparseReco['RecoFD'].GetAxis(6).SetRange(1, 2)  # make sure it is signal
-                #TODO: add other particles
-                sparseReco['RecoPrompt'].GetAxis(axisNum).SetRange(binMin, binMax)
-                sparseReco['RecoFD'].GetAxis(axisNum).SetRange(binMin, binMax)
-
-                if enableRef:
-                    sparseReco['RecoRefl'].GetAxis(6).SetRange(3, 4)  # make sure it is reflection
-                    sparseReco['RecoRefl'].GetAxis(axisNum).SetRange(binMin, binMax)
-                    sparseReco['RecoReflPrompt'].GetAxis(6).SetRange(3, 4)  # make sure it is reflection
-                    sparseReco['RecoReflPrompt'].GetAxis(8).SetRange(2, 2)  # make sure it is prompt reflection
-                    sparseReco['RecoReflPrompt'].GetAxis(axisNum).SetRange(binMin, binMax)
-                    sparseReco['RecoReflFD'].GetAxis(6).SetRange(3, 4)  # make sure it is reflection
-                    sparseReco['RecoReflFD'].GetAxis(8).SetRange(3, 3)  # make sure it is non-prompt reflection
-                    sparseReco['RecoReflFD'].GetAxis(axisNum).SetRange(binMin, binMax)
-
-                if enableSecPeak:
-                    sparseReco['RecoSecPeakPrompt'].GetAxis(axisNum).SetRange(binMin, binMax)
-                    sparseReco['RecoSecPeakFD'].GetAxis(axisNum).SetRange(binMin, binMax)
-
-            ## apply pt weights
-            for iVar in ('InvMass', 'Pt'):
-                hVarRefl, hVarReflPrompt, hVarReflFD, hVarPrompt, hVarFD = None, None, None, None, None
-                varName = 'Pt' if iVar == 'Pt' else 'Mass'
-                axisNum = cutVars[iVar]['axisnum']
-                if 'RecoAll' in sparseReco:
-                    hVar = sparseReco['RecoAll'].Projection(axisNum)
-                    hVar.SetName(f'h{varName}_{ptLowLabel:.0f}_{ptHighLabel:.0f}')
-                    outfile.cd()
-                    all_dict[iVar].append(hVar)
-                    hVar.Write()
-
-                if iVar != 'Pt':
-                    hVarPrompt = sparseReco['RecoPrompt'].Projection(axisNum)
-                    hVarPrompt.SetName(f'hPrompt{varName}_{ptLowLabel:.0f}_{ptHighLabel:.0f}')
-                    hVarFD = sparseReco['RecoFD'].Projection(axisNum)
-                    hVarFD.SetName(f'hFD{varName}_{ptLowLabel:.0f}_{ptHighLabel:.0f}')
-                else:
-                    ### no pt weights
-                    if not ptweights and not ptweightsB:
-                        hVarPrompt = sparseReco['RecoPrompt'].Projection(axisNum)
-                        hVarFD = sparseReco['RecoFD'].Projection(axisNum)
-
-                    ### pt weights for prompt
-                    if ptweights:
-                        hVarPrompt = sparseReco['RecoPrompt'].Projection(axisNum)
-                        for iBin in range(1, hVarPrompt.GetNbinsX()+1):
-                            if hVarPrompt.GetBinContent(iBin) > 0.:
-                                relStatUnc = hVarPrompt.GetBinError(iBin) / hVarPrompt.GetBinContent(iBin)
-                                ptCent = hVarPrompt.GetBinCenter(iBin)
-                                hVarPrompt.SetBinContent(iBin, hVarPrompt.GetBinContent(iBin) * sPtWeights(ptCent))
-                                hVarPrompt.SetBinError(iBin, hVarPrompt.GetBinContent(iBin) * relStatUnc)
-                    
-                    ### pt weights for non-prompt, but no B species weights
-                    if ptweightsB and not Bspeciesweights:
-                        hPtBvsPtD = sparseReco['RecoFD'].Projection(2, axisNum)
-                        for iPtD in range(1, hPtBvsPtD.GetXaxis().GetNbins()+1):
-                            for iPtB in range(1, hPtBvsPtD.GetYaxis().GetNbins()+1):
-                                ptCentB = hPtBvsPtD.GetYaxis().GetBinCenter(iPtB)
-                                origContent = hPtBvsPtD.GetBinContent(iPtD, iPtB)
-                                origError = hPtBvsPtD.GetBinError(iPtD, iPtB)
-                                weight = 0
-                                if sPtWeightsB(ptCentB) > 0:
-                                    weight = sPtWeightsB(ptCentB)
-                                content = origContent * weight
-                                error = 0
-                                if origContent > 0:
-                                    error = origError / origContent * content
-                                hPtBvsPtD.SetBinContent(iPtD, iPtB, content)
-                                hPtBvsPtD.SetBinError(iPtD, iPtB, error)
-                        hVarFD = hPtBvsPtD.ProjectionX(f'hFD{varName}_{ptLowLabel:.0f}_{ptHighLabel:.0f}',
-                                                        0, hPtBvsPtD.GetYaxis().GetNbins()+1, 'e')
-                    ### pt weights from B for non-prompt and B species weights
-                    elif ptweightsB and Bspeciesweights:
-                        hPtBvsBspecievsPtD = sparseReco['RecoFD'].Projection(axisNum, 3, 2)
-                        for iPtD in range(1, hPtBvsBspecievsPtD.GetXaxis().GetNbins()+1):
-                            for iBspecie in range(1, hPtBvsBspecievsPtD.GetYaxis().GetNbins()+1):
-                                for iPtB in range(1, hPtBvsBspecievsPtD.GetZaxis().GetNbins()+1):
-                                    ptCentB = hPtBvsBspecievsPtD.GetZaxis().GetBinCenter(iPtB)
-                                    origContent = hPtBvsBspecievsPtD.GetBinContent(iPtD, iBspecie, iPtB)
-                                    origError = hPtBvsBspecievsPtD.GetBinError(iPtD, iBspecie, iPtB)
-                                    weight = Bspeciesweights[iBspecie-1]
-                                    if sPtWeightsB(ptCentB) > 0:
-                                        weight *= sPtWeightsB(ptCentB)
-                                    content = origContent * weight
-                                    error = 0
-                                    if origContent > 0:
-                                        error = origError / origContent * content
-                                    hPtBvsBspecievsPtD.SetBinContent(iPtD, iBspecie, iPtB, content)
-                                    hPtBvsBspecievsPtD.SetBinError(iPtD, iBspecie, iPtB, error)
-                        hVarFD = hPtBvsBspecievsPtD.ProjectionX(f'hFD{varName}_{ptLowLabel:.0f}_{ptHighLabel:.0f}',
-                                                                0, hPtBvsBspecievsPtD.GetYaxis().GetNbins()+1,
-                                                                0, hPtBvsBspecievsPtD.GetZaxis().GetNbins()+1, 'e')
-                    ### only B species weights
-                    elif Bspeciesweights:
-                        hBspecievsPtD = sparseReco['RecoFD'].Projection(3, axisNum)
-                        for iPtD in range(1, hBspecievsPtD.GetXaxis().GetNbins()+1):
-                            for iBspecie in range(1, hBspecievsPtD.GetYaxis().GetNbins()+1):
-                                origContent = hBspecievsPtD.GetBinContent(iPtD, iBspecie)
-                                origError = hBspecievsPtD.GetBinError(iPtD, iBspecie)
-                                weight = Bspeciesweights[iBspecie-1]
-                                content = origContent * weight
-                                error = 0
-                                if origContent > 0:
-                                    error = origError / origContent * content
-                                hBspecievsPtD.SetBinContent(iPtD, iBspecie, content)
-                                hBspecievsPtD.SetBinError(iPtD, iBspecie, error)
-                        hVarFD = hBspecievsPtD.ProjectionX(f'hFD{varName}_{ptLowLabel:.0f}_{ptHighLabel:.0f}',
-                                                        0, hBspecievsPtD.GetYaxis().GetNbins()+1, 'e')
-                    ### use the pt weights from prompt for non-prompt
-                    elif ptweights: # if pt weights for prompt are present apply them
-                        for iBin in range(1, hVarFD.GetNbinsX()+1):
-                                if hVarFD.GetBinContent(iBin) > 0.:
-                                    relStatUnc = hVarFD.GetBinError(iBin) / hVarFD.GetBinContent(iBin)
-                                    ptCent = hVarFD.GetBinCenter(iBin)
-                                    hVarFD.SetBinContent(iBin, hVarFD.GetBinContent(iBin) * sPtWeights(ptCent))
-                                    hVarFD.SetBinError(iBin, hVarFD.GetBinContent(iBin) * relStatUnc)
-
-                ## wirte teh output           
-                hVarPrompt.SetName(f'hPrompt{varName}_{ptLowLabel:.0f}_{ptHighLabel:.0f}')
-                prompt_dict[iVar].append(hVarPrompt)
-                hVarPrompt.Write()
-                hVarFD.SetName(f'hFD{varName}_{ptLowLabel:.0f}_{ptHighLabel:.0f}')
-                fd_dict[iVar].append(hVarFD)
-                hVarFD.Write()
-                if enableRef:
-                    hVarRefl = sparseReco['RecoRefl'].Projection(axisNum)
-                    hVarRefl.SetName(f'hVarRefl{varName}_{ptLowLabel:.0f}_{ptHighLabel:.0f}')
-                    refl_dict[iVar].append(hVarRefl)
-                    hVarRefl.Write()
-                    hVarReflPrompt = sparseReco['RecoReflPrompt'].Projection(axisNum)
-                    hVarReflPrompt.SetName(f'hVarReflPrompt{varName}_{ptLowLabel:.0f}_{ptHighLabel:.0f}')
-                    refl_dict[iVar].append(hVarReflPrompt)
-                    hVarReflPrompt.Write()
-                    hVarReflFD = sparseReco['RecoReflFD'].Projection(axisNum)
-                    hVarReflFD.SetName(f'hVarReflFD{varName}_{ptLowLabel:.0f}_{ptHighLabel:.0f}')
-                    refl_dict[iVar].append(hVarReflFD)
-                    hVarReflFD.Write()
-                if enableSecPeak:
-                    hVarPromptSecPeak = sparseReco['RecoSecPeakPrompt'].Projection(axisNum)
-                    hVarPromptSecPeak.SetName(f'hPromptSecPeak{varName}_{ptLowLabel:.0f}_{ptHighLabel:.0f}')
-                    prompt_dict_secpeak[iVar].append(hVarPromptSecPeak)
-                    hVarPromptSecPeak.Write()
-                    hVarFDSecPeak = sparseReco['RecoSecPeakFD'].Projection(axisNum)
-                    hVarFDSecPeak.SetName(f'hFDSecPeak{varName}_{ptLowLabel:.0f}_{ptHighLabel:.0f}')
-                    fd_dict_secpeak[iVar].append(hVarFDSecPeak)
-                    hVarFDSecPeak.Write()
-            # end of apply pt weights for reconstruction level
-
-            # apply pt weights for generation level
-            binGenMin = sparseGen['GenPrompt'].GetAxis(0).FindBin(ptMin*1.0001)
-            binGenMax = sparseGen['GenPrompt'].GetAxis(0).FindBin(ptMax*0.9999)
-            if particleName == 'Dzero':
-                sparseGen['GenPrompt'].GetAxis(3).SetRange(2, 2)  # make sure it is prompt
-                sparseGen['GenFD'].GetAxis(3).SetRange(3, 3)  # make sure it is non-prompt
-            sparseGen['GenPrompt'].GetAxis(0).SetRange(binGenMin, binGenMax)
-            sparseGen['GenFD'].GetAxis(0).SetRange(binGenMin, binGenMax)
-
-            ## no pt weights
-            if not ptweights and not ptweightsB:
-                hGenPtPrompt = sparseGen['GenPrompt'].Projection(0)
-                hGenPtFD = sparseGen['GenFD'].Projection(0)
-
-            ## apply pt weights for prompt
-            if ptweights:
-                hGenPtPrompt = sparseGen['GenPrompt'].Projection(0)
-                for iBin in range(1, hGenPtPrompt.GetNbinsX()+1):
-                    if hGenPtPrompt.GetBinContent(iBin) > 0:
-                        relStatUnc = hGenPtPrompt.GetBinError(iBin) / hGenPtPrompt.GetBinContent(iBin)
-                        ptCent = hGenPtPrompt.GetBinCenter(iBin)
-                        hGenPtPrompt.SetBinContent(iBin, hGenPtPrompt.GetBinContent(iBin) * sPtWeights(ptCent))
-                        hGenPtPrompt.SetBinError(iBin, hGenPtPrompt.GetBinContent(iBin) * relStatUnc)
-
-            ## apply pt weights for non-prompt
-            ### pt weights from B for non-prompt, but no B species weights
-            if ptweightsB and not Bspeciesweights:
-                hPtBvsPtGenD = sparseGen['GenFD'].Projection(2, 0)
-                for iPtD in range(1, hPtBvsPtGenD.GetXaxis().GetNbins()+1):
-                    for iPtB in range(1, hPtBvsPtGenD.GetYaxis().GetNbins()+1):
-                        ptCentB = hPtBvsPtGenD.GetYaxis().GetBinCenter(iPtB)
-                        origContent = hPtBvsPtGenD.GetBinContent(iPtD, iPtB)
-                        origError = hPtBvsPtGenD.GetBinError(iPtD, iPtB)
-                        weight = 0
-                        if sPtWeightsB(ptCent) > 0:
-                            weight = sPtWeightsB(ptCentB)
-                        content = hPtBvsPtGenD.GetBinContent(iPtD, iPtB) * weight
-                        error = 0
-                        if origContent > 0:
-                            error = origError / origContent * content
-                        hPtBvsPtGenD.SetBinContent(iPtD, iPtB, content)
-                        hPtBvsPtGenD.SetBinError(iPtD, iPtB, error)
-                hGenPtFD = hPtBvsPtGenD.ProjectionX(f'hFDGenPt_{ptLowLabel:.0f}_{ptHighLabel:.0f}',
-                                                    0, hPtBvsPtGenD.GetYaxis().GetNbins()+1, 'e')
-            ### pt weights from B for non-prompt and B species weights
-            elif ptweightsB and Bspeciesweights:
-                hPtBvsBspecievsPtGenD = sparseGen['GenFD'].Projection(0, 3, 2)
-                for iPtD in range(1, hPtBvsBspecievsPtGenD.GetXaxis().GetNbins()+1):
-                    for iBspecie in range(1, hPtBvsBspecievsPtGenD.GetYaxis().GetNbins()+1):
-                        for iPtB in range(1, hPtBvsBspecievsPtGenD.GetZaxis().GetNbins()+1):
-                            ptCentB = hPtBvsBspecievsPtGenD.GetZaxis().GetBinCenter(iPtB)
-                            origContent = hPtBvsBspecievsPtGenD.GetBinContent(iPtD, iBspecie, iPtB)
-                            origError = hPtBvsBspecievsPtGenD.GetBinError(iPtD, iBspecie, iPtB)
-                            weight = Bspeciesweights[iBspecie-1]
-                            if sPtWeightsB(ptCentB) > 0:
-                                weight *= sPtWeightsB(ptCentB)
-                            content = origContent * weight
-                            error = 0
-                            if origContent > 0:
-                                error = origError / origContent * content
-                            hPtBvsBspecievsPtGenD.SetBinContent(iPtD, iBspecie, iPtB, content)
-                            hPtBvsBspecievsPtGenD.SetBinError(iPtD, iBspecie, iPtB, error)
-                hGenPtFD = hPtBvsBspecievsPtGenD.ProjectionX(f'hFDGenPt_{ptLowLabel:.0f}_{ptHighLabel:.0f}',
-                                                            0, hPtBvsBspecievsPtGenD.GetYaxis().GetNbins()+1,
-                                                            0, hPtBvsBspecievsPtGenD.GetZaxis().GetNbins()+1, 'e')
-            ### only B species weights
-            elif Bspeciesweights:
-                hBspecievsPtGenD = sparseGen['GenFD'].Projection(3, 0)
-                for iPtD in range(1, hBspecievsPtGenD.GetXaxis().GetNbins()+1):
-                    for iBspecie in range(1, hBspecievsPtGenD.GetYaxis().GetNbins()+1):
-                        origContent = hBspecievsPtGenD.GetBinContent(iPtD, iBspecie)
-                        origError = hBspecievsPtGenD.GetBinError(iPtD, iBspecie)
-                        weight = Bspeciesweights[iBspecie-1]
-                        content = origContent * weight
-                        error = 0
-                        if origContent > 0:
-                            error = origError / origContent * content
-                        hBspecievsPtGenD.SetBinContent(iPtD, iBspecie, content)
-                        hBspecievsPtGenD.SetBinError(iPtD, iBspecie, error)
-                hGenPtFD = hBspecievsPtGenD.ProjectionX(f'hFDGenPt_{ptLowLabel:.0f}_{ptHighLabel:.0f}',
-                                                        0, hBspecievsPtGenD.GetYaxis().GetNbins()+1, 'e')
-            ### use the pt weights from prompt for non-prompt
-            elif ptweights: # if pt weights for prompt are present apply them
-                hGenPtFD = sparseGen['GenFD'].Projection(0)
-                            
-            ## print the output
-            hGenPtPrompt.SetName(f'hPromptGenPt_{ptLowLabel:.0f}_{ptHighLabel:.0f}')
-            prompt_gen_list.append(hGenPtPrompt)
-            hGenPtPrompt.Write()
-            hGenPtFD.SetName(f'hFDGenPt_{ptLowLabel:.0f}_{ptHighLabel:.0f}')
-            fd_gen_list.append(hGenPtFD)
-            hGenPtFD.Write()
-            if enableSecPeak:
-                sparseGen['GenSecPeakPrompt'].GetAxis(0).SetRange(binGenMin, binGenMax)
-                sparseGen['GenSecPeakFD'].GetAxis(0).SetRange(binGenMin, binGenMax)
-                hGenPtPromptSecPeak = sparseGen['GenSecPeakPrompt'].Projection(0)
-                hGenPtPromptSecPeak.SetName(f'hPromptSecPeakGenPt_{ptLowLabel:.0f}_{ptHighLabel:.0f}')
-                prompt_gen_list_secpeak.append(hGenPtPromptSecPeak)
-                hGenPtPromptSecPeak.Write()
-                hGenPtFDSecPeak = sparseGen['GenSecPeakFD'].Projection(0)
-                hGenPtFDSecPeak.SetName(f'hFDSecPeakGenPt_{ptLowLabel:.0f}_{ptHighLabel:.0f}')
-                fd_gen_list_secpeak.append(hGenPtFDSecPeak)
-                hGenPtFDSecPeak.Write()
-
-            bar()
-
-        for iVar in cutVars:
-            axisNum = cutVars[iVar]['axisnum']
-            if 'RecoAll' in sparseReco:
-                sparseReco['RecoAll'].GetAxis(axisNum).SetRange(-1, -1)
-            sparseReco['RecoPrompt'].GetAxis(axisNum).SetRange(-1, -1)
-            sparseReco['RecoFD'].GetAxis(axisNum).SetRange(-1, -1)
-            if enableRef:
-                sparseReco['RecoRefl'].GetAxis(axisNum).SetRange(-1, -1)
-                sparseReco['RecoReflPrompt'].GetAxis(axisNum).SetRange(-1, -1)
-                sparseReco['RecoReflFD'].GetAxis(axisNum).SetRange(-1, -1)
-            if enableSecPeak:
-                sparseReco['RecoSecPeakPrompt'].GetAxis(axisNum).SetRange(-1, -1)
-                sparseReco['RecoSecPeakFD'].GetAxis(axisNum).SetRange(-1, -1)
-
-    infile = ROOT.TFile(inputFiles[0])
-    if particleName in ['Dplus', 'Ds']:
-        cent_hist = infile.Get('hf-candidate-creator-3prong/hSelCollisionsCent')
-        outfile_dir = 'hf-candidate-creator-3prong'
-    elif particleName == 'Dzero':
-        cent_hist = infile.Get('hf-candidate-creator-2prong/hSelCollisionsCent')
-        outfile_dir = 'hf-candidate-creator-2prong'
-    outfile.mkdir(outfile_dir)
-    outfile.cd(outfile_dir)
-    cent_hist.Write()
-
-    infile.Close()
-    outfile.Close()
+    return ptWeights, ptWeightsB, Bspeciesweights, sPtWeights, sPtWeightsB
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Arguments")
@@ -403,19 +294,117 @@ if __name__ == "__main__":
                         default="config.yaml", help="flow configuration file")
     parser.add_argument('cutsetConfig', metavar='text',
                         default='cutsetConfig.yaml', help='cutset configuration file')
+    parser.add_argument('--preprocessed', action='store_true', 
+                        help='Determines whether the sparses are pre-processed')
     parser.add_argument("--ptweights", "-w", metavar="text", nargs=2, required=False,
                         default=[], help="path to pt weights file and histogram name")
     parser.add_argument("--ptweightsB", "-wb", metavar="text", nargs=2, required=False,
                         default=[], help="path to pt weightsB file and histogram name")
+    parser.add_argument("--centrality", "-c", metavar="text",
+                        default="k3050", help="centrality class")
+    parser.add_argument("--resolution", "-r", metavar="text",
+                        default="reso.root", help="resolution file")
     parser.add_argument("--outputdir", "-o", metavar="text",
                         default=".", help="output directory")
     parser.add_argument("--suffix", "-s", metavar="text",
                         default="", help="suffix for output files")
     args = parser.parse_args()
 
-    proj_MC(config=args.config,
-            cutsetConfig=args.cutsetConfig,
-            ptweights=args.ptweights,
-            ptweightsB=args.ptweightsB,
-            outputdir=args.outputdir,
-            suffix=args.suffix)
+    with open(args.config, 'r') as ymlCfgFile:
+        config = yaml.load(ymlCfgFile, yaml.FullLoader)
+
+    os.makedirs(f'{args.outputdir}/proj', exist_ok=True)
+    outfile = ROOT.TFile(f'{args.outputdir}/proj/proj_{args.suffix}.root', 'RECREATE')
+    
+    cent, (cent_min, cent_max) = get_centrality_bins(args.centrality)
+    outfile_dir = 'hf-candidate-creator-2prong' if config['Dmeson'] == 'Dzero' else 'hf-candidate-creator-3prong'
+    infilemc = TFile.Open(config['MC_filename'], 'r')
+    histo_cent = infilemc.Get(f'{outfile_dir}/hSelCollisionsCent')
+    histo_cent.GetXaxis().SetRangeUser(cent_min, cent_max)
+    resofile = TFile.Open(args.resolution, 'r')
+    try:
+        det_A = config['detA']
+        det_B = config['detB']
+        det_C = config['detC']
+        histo_reso = resofile.Get(f'{det_A}_{det_B}_{det_C}/histo_reso_delta_cent')
+        histo_reso.SetName('histo_reso_delta_cent')
+        histo_reso.SetDirectory(0)
+        reso = histo_reso.GetBinContent(1)
+    except:
+        histo_reso = resofile.Get(f'hf-task-flow-charm-hadrons/spReso/hSpReso{det_B}{det_C}')
+        histo_reso.SetName('histo_reso_delta_cent')
+        histo_reso.SetDirectory(0)
+        reso = histo_reso.GetBinContent(1)
+    
+    outfile.cd()
+    histo_reso.Write()
+    outfile.mkdir(outfile_dir)
+    outfile.cd(outfile_dir)
+    histo_cent.Write()
+    resofile.Close()
+    infilemc.Close()
+
+    # load thnsparse
+    sparsesFlow, sparsesReco, sparsesGen, axes = get_sparses(config, True, True, True, args.preprocessed, f'{config["skimDir"]}')
+    if not args.preprocessed:
+        for key, iSparse in sparsesFlow.items():
+            iSparse.GetAxis(axes['Flow']['cent']).SetRangeUser(cent_min, cent_max)
+    for key, iSparse in sparsesGen.items():
+        iSparse.GetAxis(axes[key]['cent']).SetRangeUser(cent_min, cent_max)
+    for key, iSparse in sparsesReco.items():
+        iSparse.GetAxis(axes[key]['cent']).SetRangeUser(cent_min, cent_max)
+
+    with open(args.cutsetConfig, 'r') as ymlCutSetFile:
+        cutSetCfg = yaml.load(ymlCutSetFile, yaml.FullLoader)
+    cutVars = cutSetCfg['cutvars']
+
+    # compute info for pt weights
+    ptWeights, ptWeightsB, Bspeciesweights, sPtWeights, sPtWeightsB = pt_weights_info(args.ptweights, args.ptweightsB)
+
+    with alive_bar(len(cutVars['Pt']['min']), title='Processing pT bins') as bar:
+        for iPt, (ptMin, ptMax) in enumerate(zip(cutVars['Pt']['min'], cutVars['Pt']['max'])):
+            print(f'Projecting distributions for {ptMin:.1f} < pT < {ptMax:.1f} GeV/c')
+            ptLowLabel = ptMin * 10
+            ptHighLabel = ptMax * 10
+            outfile.mkdir(f'cent_bins{cent}/pt_bins{int(ptLowLabel)}_{int(ptHighLabel)}')
+            outfile.cd(f'cent_bins{cent}/pt_bins{int(ptLowLabel)}_{int(ptHighLabel)}')
+    
+            print(f"sparsesFlow: {sparsesFlow}")
+            if args.preprocessed:
+                print('PREPROCESSED')
+                sparsesFlow[f"Flow_{ptLowLabel}_{ptHighLabel}"].GetAxis(axes['Flow']['score_FD']).SetRangeUser(cutVars['score_FD']['min'][iPt], cutVars['score_FD']['max'][iPt])
+                proj_data(sparsesFlow[f"Flow_{ptLowLabel}_{ptHighLabel}"], ptMin, ptMax, axes, config['inv_mass_bins'][iPt], reso)
+                file_proj = TFile(f'{args.outputdir}/proj/ProjFlow_{args.suffix}.root', 'recreate')
+                for idim in range(sparsesFlow[f"Flow_{ptLowLabel}_{ptHighLabel}"].GetNdimensions()):
+                    histo = sparsesFlow[f"Flow_{ptLowLabel}_{ptHighLabel}"].Projection(idim)
+                    histo.Write()
+                file_proj.Close()
+                outfile.cd(f'cent_bins{cent}/pt_bins{int(ptLowLabel)}_{int(ptHighLabel)}')
+                print(f"Projected data!")
+            
+            if not args.preprocessed:
+                print('NOT PREPROCESSED')
+                for iSparse, (key, sparse) in enumerate(sparsesFlow.items()):
+                    for iVar in cutVars:
+                        sparse.GetAxis(axes['Flow'][iVar]).SetRangeUser(cutVars[iVar]['min'][iPt], cutVars[iVar]['max'][iPt])
+                proj_data(sparsesFlow, ptMin, ptMax, axes, config['inv_mass_bins'][iPt], reso)
+                print(f"Projected data!")
+            
+            for iVar in cutVars:
+                for key, iSparse in sparsesReco.items():
+                    iSparse.GetAxis(axes[key][iVar]).SetRangeUser(cutVars[iVar]['min'][iPt], cutVars[iVar]['max'][iPt])
+                if iVar == 'Pt':
+                    for key, iSparse in sparsesGen.items():
+                        iSparse.GetAxis(axes[key][iVar]).SetRangeUser(cutVars[iVar]['min'][iPt], cutVars[iVar]['max'][iPt])
+                if iVar == 'score_FD' or iVar == 'score_bkg':
+                    print(f'{iVar}: {cutVars[iVar]["min"][iPt]} < {iVar} < {cutVars[iVar]["max"][iPt]}')
+
+            proj_mc_reco(config, ptWeights, ptWeightsB, Bspeciesweights, sPtWeights, sPtWeightsB)
+            print(f"Projected mc reco!")
+            proj_mc_gen(config, ptWeights, ptWeightsB, Bspeciesweights, sPtWeights, sPtWeightsB)
+            print(f"Projected mc gen!")
+            
+            bar()
+    
+    outfile.Close()
+    outfile.Close()

--- a/run3/flow/BDT/proj_thn_mc.py
+++ b/run3/flow/BDT/proj_thn_mc.py
@@ -20,16 +20,16 @@ from flow_analysis_utils import get_vn_versus_mass, get_centrality_bins
 ### please fill your path of DmesonAnalysis
 sys.path.append('../../..')
 
-def proj_data(sparse_flow, ptMin, ptMax, axes, inv_mass_bins, reso):
+def proj_data(sparse_flow, ptMin, ptMax, centMin, centMax, axes, inv_mass_bins, reso):
 
     if isinstance(sparse_flow, dict):
         for isparse, (key, sparse) in enumerate(sparse_flow.items()):
             hist_mass_temp = sparse.Projection(axes['Flow']['Mass'])
-            hist_mass_temp.SetName(f'hist_mass_proj_{isparse}')
+            hist_mass_temp.SetName(f'hist_mass_{isparse}')
             hist_mass_temp.SetDirectory(0)
 
             if isparse == 0:
-                hist_mass = hist_mass_temp.Clone('hist_mass_proj')
+                hist_mass = hist_mass_temp.Clone('hist_mass')
                 hist_mass.SetDirectory(0)
                 hist_mass.Reset()
 
@@ -46,8 +46,8 @@ def proj_data(sparse_flow, ptMin, ptMax, axes, inv_mass_bins, reso):
         if reso > 0:
             hist_vn_sp.Scale(1./reso)
 
-    hist_mass.Write(f'hist_mass_proj_pt{int(ptMin*10)}_{int(ptMax*10)}')
-    hist_vn_sp.Write(f'hist_vn_sp_proj_pt{int(ptMin*10)}_{int(ptMax*10)}')
+    hist_mass.Write(f'hist_mass_cent{centMin}_{centMax}_pt{ptMin}_{ptMax}')
+    hist_vn_sp.Write(f'hist_vn_sp_pt{ptMin}_{ptMax}')
 
 def proj_mc_reco(config, ptWeights, ptWeightsB, Bspeciesweights, sPtWeights, sPtWeightsB):
     
@@ -327,7 +327,7 @@ if __name__ == "__main__":
         det_B = config['detB']
         det_C = config['detC']
         histo_reso = resofile.Get(f'{det_A}_{det_B}_{det_C}/histo_reso_delta_cent')
-        histo_reso.SetName('histo_reso_delta_cent')
+        histo_reso.SetName('hist_reso')
         histo_reso.SetDirectory(0)
         reso = histo_reso.GetBinContent(1)
     except:
@@ -366,20 +366,15 @@ if __name__ == "__main__":
             print(f'Projecting distributions for {ptMin:.1f} < pT < {ptMax:.1f} GeV/c')
             ptLowLabel = ptMin * 10
             ptHighLabel = ptMax * 10
-            outfile.mkdir(f'cent_bins{cent}/pt_bins{int(ptLowLabel)}_{int(ptHighLabel)}')
-            outfile.cd(f'cent_bins{cent}/pt_bins{int(ptLowLabel)}_{int(ptHighLabel)}')
+            outfile.mkdir(f'cent_bins{cent}/pt_bins{ptMin}_{ptMax}')
+            outfile.cd(f'cent_bins{cent}/pt_bins{ptMin}_{ptMax}')
     
             print(f"sparsesFlow: {sparsesFlow}")
             if args.preprocessed:
                 print('PREPROCESSED')
                 sparsesFlow[f"Flow_{ptLowLabel}_{ptHighLabel}"].GetAxis(axes['Flow']['score_FD']).SetRangeUser(cutVars['score_FD']['min'][iPt], cutVars['score_FD']['max'][iPt])
-                proj_data(sparsesFlow[f"Flow_{ptLowLabel}_{ptHighLabel}"], ptMin, ptMax, axes, config['inv_mass_bins'][iPt], reso)
-                file_proj = TFile(f'{args.outputdir}/proj/ProjFlow_{args.suffix}.root', 'recreate')
-                for idim in range(sparsesFlow[f"Flow_{ptLowLabel}_{ptHighLabel}"].GetNdimensions()):
-                    histo = sparsesFlow[f"Flow_{ptLowLabel}_{ptHighLabel}"].Projection(idim)
-                    histo.Write()
-                file_proj.Close()
-                outfile.cd(f'cent_bins{cent}/pt_bins{int(ptLowLabel)}_{int(ptHighLabel)}')
+                proj_data(sparsesFlow[f"Flow_{ptLowLabel}_{ptHighLabel}"], ptMin, ptMax, cent_min, cent_max, axes, config['inv_mass_bins'][iPt], reso)
+                outfile.cd(f'cent_bins{cent}/pt_bins{ptMin}_{ptMax}')
                 print(f"Projected data!")
             
             if not args.preprocessed:

--- a/run3/flow/BDT/run_cutvar.py
+++ b/run3/flow/BDT/run_cutvar.py
@@ -19,7 +19,8 @@ def check_dir(dir):
 
 	return
 
-def run_full_cut_variation(config_flow, anres_dir, cent, res_file, output, suffix, vn_method, 
+def run_full_cut_variation(config_flow, anres_dir, cent, res_file, output, suffix, vn_method, use_preprocessed, 
+						   skip_preprocess=False,
 						   skip_calc_weights=False,
 						   skip_make_yaml=False, 
 						   skip_cut_variation=False,
@@ -55,6 +56,18 @@ def run_full_cut_variation(config_flow, anres_dir, cent, res_file, output, suffi
 	os.system(f'cp {config_flow} {output_dir}/config_flow_{suffix}_{config_suffix}.yml')
 
 #___________________________________________________________________________________________________________________________
+	# preprocess the AnalysisResults.root files
+	if not skip_preprocess:
+		use_preprocessed = True
+		check_dir(f"{output_dir}/proj")
+		PreProcessPath = "../../tool/pre_process.py"
+
+		print(f"\033[32mpython3 {PreProcessPath} {config_flow} {output} --pre -s {suffix}\033[0m")
+		os.system(f"python3 {PreProcessPath} {config_flow} {output} --pre -s {suffix}")
+	else:
+		print("\033[33mWARNING: Pre-process will not be performed\033[0m")
+
+#___________________________________________________________________________________________________________________________
 	# calculate the pT weights
 	if not skip_calc_weights:
 		check_dir(f"{output_dir}/ptweights")
@@ -70,48 +83,37 @@ def run_full_cut_variation(config_flow, anres_dir, cent, res_file, output, suffi
 	if not skip_make_yaml:
 		check_dir(f"{output_dir}/config")
 		MakeyamlPath = './make_yaml_for_ml.py'
+		pre_process = "--preprocessed" if not skip_preprocess else ""
 
-		print(f"\033[32mpython3 {MakeyamlPath} {config_flow} -o {output_dir} -s {suffix}\033[0m")
-		os.system(f"python3 {MakeyamlPath} {config_flow} -o {output_dir} -s {suffix}")
+		print(f"\033[32mpython3 {MakeyamlPath} {config_flow} {pre_process} -o {output_dir} -s {suffix}\033[0m")
+		os.system(f"python3 {MakeyamlPath} {config_flow} {pre_process} -o {output_dir} -s {suffix}")
 	else:
 		print("\033[33mWARNING: Make yaml will not be performed\033[0m")
 	#TODO: 1.keep the yaml file for the user to check 2.modify the proj_thn_mc 3.use make_combination in proj_thn_mc.py
 
 #___________________________________________________________________________________________________________________________
-	# Cut variation (aply the cut and project)
-	if not skip_cut_variation:
-		check_dir(f"{output_dir}/proj")
-		CutVarPath = "./cut_variation.py"
-
-		anres_files = " ".join(anres_dir)
-		print(f"\033[32mpython3 {CutVarPath} {config_flow} {anres_files} -c {cent} -r {res_file} -o {output_dir} -s {suffix}\033[0m")
-		os.system(f"python3 {CutVarPath} {config_flow} {anres_files} -c {cent} -r {res_file} -o {output_dir} -s {suffix}")
-	else:
-		print("\033[33mWARNING: Cut variation will not be performed\033[0m")
-
-#___________________________________________________________________________________________________________________________
 	# Projection for MC and apply the ptweights
 	if not skip_proj_mc:
-		check_dir(f"{output_dir}/proj_mc")
+		check_dir(f"{output_dir}/proj")
 		ProjMcPath = "./proj_thn_mc.py"
-		
+		pre_process = "--preprocessed" if use_preprocessed else ""
 		if not os.path.exists(f'{output_dir}/ptweights/pTweight_{suffix}.root'):
 			for i in range(nCutSets):
 				iCutSets = f"{i:02d}"
-				print(f"\033[32mpython3 {ProjMcPath} {config_flow} {output_dir}/config/cutset_{suffix}_{iCutSets}.yml -o {output_dir} -s {suffix}_{iCutSets}\033[0m")
-				os.system(f"python3 {ProjMcPath} {config_flow} {output_dir}/config/cutset_{suffix}_{iCutSets}.yml -o {output_dir} -s {suffix}_{iCutSets}")
+				print(f"\033[32mpython3 {ProjMcPath} {config_flow} {output_dir}/config/cutset_{suffix}_{iCutSets}.yml {pre_process} -c {cent} -r {res_file} -o {output_dir} -s {suffix}_{iCutSets}\033[0m")
+				os.system(f"python3 {ProjMcPath} {config_flow} {output_dir}/config/cutset_{suffix}_{iCutSets}.yml {pre_process} -c {cent} -r {res_file} -o {output_dir} -s {suffix}_{iCutSets}")
 		else:
 			for i in range(nCutSets):
 				iCutSets = f"{i:02d}"
 				print(
-					f"\033[32mpython3 {ProjMcPath} {config_flow} {output_dir}/config/cutset_{suffix}_{iCutSets}.yml "
+					f"\033[32mpython3 {ProjMcPath} {config_flow} {output_dir}/config/cutset_{suffix}_{iCutSets}.yml {pre_process} "
 					f"-w {output_dir}/ptweights/pTweight_{suffix}.root hPtWeightsFONLLtimesTAMUDcent "
 					f"-wb {output_dir}/ptweights/pTweight_{suffix}.root hPtWeightsFONLLtimesTAMUBcent "
-					f"-o {output_dir} -s {suffix}_{iCutSets} \033[0m"
+					f"-c {cent} -r {res_file} -o {output_dir} -s {suffix}_{iCutSets} \033[0m"
 				)
-				os.system(f"python3 {ProjMcPath} {config_flow} {output_dir}/config/cutset_{suffix}_{iCutSets}.yml \
+				os.system(f"python3 {ProjMcPath} {config_flow} {output_dir}/config/cutset_{suffix}_{iCutSets}.yml {pre_process} \
 						-w {output_dir}/ptweights/pTweight_{suffix}.root hPtWeightsFONLLtimesTAMUDcent \
-						-wb {output_dir}/ptweights/pTweight_{suffix}.root hPtWeightsFONLLtimesTAMUBcent -o {output_dir} -s {suffix}_{iCutSets}")
+						-wb {output_dir}/ptweights/pTweight_{suffix}.root hPtWeightsFONLLtimesTAMUBcent -c {cent} -r {res_file} -o {output_dir} -s {suffix}_{iCutSets}")
 
 	else:
 		print("\033[33mWARNING: Projection for MC will not be performed\033[0m")							
@@ -124,11 +126,12 @@ def run_full_cut_variation(config_flow, anres_dir, cent, res_file, output, suffi
 
 		for i in range(nCutSets):
 			iCutSets = f"{i:02d}"
-			print(f"\033[32mpython3 {EffPath} {config_flow} {output_dir}/proj_mc/proj_mc_{suffix}_{iCutSets}.root -c {cent} -o {output_dir} -s {suffix}_{iCutSets}\033[0m")
+			print(f"\033[32mpython3 {EffPath} {config_flow} {output_dir}/proj/proj_{suffix}_{iCutSets}.root -c {cent} -o {output_dir} -s {suffix}_{iCutSets}\033[0m")
 			print(f"\033[32mProcessing cutset {iCutSets}\033[0m")
-			os.system(f"python3 {EffPath} {config_flow} {output_dir}/proj_mc/proj_mc_{suffix}_{iCutSets}.root -c {cent} -o {output_dir} -s {suffix}_{iCutSets} --batch")
+			os.system(f"python3 {EffPath} {config_flow} {output_dir}/proj/proj_{suffix}_{iCutSets}.root -c {cent} -o {output_dir} -s {suffix}_{iCutSets} --batch")
 	else:
 		print("\033[33mWARNING: Efficiency will not be performed\033[0m")
+	# quit()
 
 #___________________________________________________________________________________________________________________________
 	# do the simulation fit to get the raw yields
@@ -189,6 +192,8 @@ if __name__ == "__main__":
 	parser.add_argument("--outputdir", "-o", metavar="text", default=".", help="output directory")
 	parser.add_argument("--suffix", "-s", metavar="text", default="", help="suffix for output files")
 	parser.add_argument("--vn_method", "-vn", metavar="text", default="sp", help="vn technique (sp, ep, deltaphi)")
+	parser.add_argument("--preprocessed", "-prep", action="store_true", help="use preprocessed input")
+	parser.add_argument("--skip_pre_process", "-sprep", action="store_true", help="skip preprocessing of AnalysisResults files")
 	parser.add_argument("--skip_calc_weights", "-scw", action="store_true", help="skip calculation of weights")
 	parser.add_argument("--skip_make_yaml", "-smy", action="store_true", help="skip make yaml")
 	parser.add_argument("--skip_cut_variation", "-scv", action="store_true", help="skip cut variation")
@@ -200,7 +205,8 @@ if __name__ == "__main__":
 	parser.add_argument("--skip_v2_vs_frac", "-sv2fd", action="store_true", help="skip v2 vs FD fraction")
 	args = parser.parse_args()
 
-	run_full_cut_variation(args.flow_config, args.anres_dir, args.centrality, args.resolution, args.outputdir, args.suffix, args.vn_method, 
+	run_full_cut_variation(args.flow_config, args.anres_dir, args.centrality, args.resolution, args.outputdir, args.suffix, args.vn_method, args.preprocessed, 
+						args.skip_pre_process,
 						args.skip_calc_weights,
 						args.skip_make_yaml, 
 						args.skip_cut_variation, 

--- a/run3/flow/BDT/run_cutvar.sh
+++ b/run3/flow/BDT/run_cutvar.sh
@@ -33,15 +33,29 @@ export vn_method="sp"
 export res_file="/media/wuct/wulby/ALICE/AnRes/resolution/output_reso/resospk3050_inte.root"
 export suffix="pt2_3"
 
+export use_prep=True # True or False (use pre-processed inputs for projections)
+export sprep=True # True or False (perform pre-processing of grid output files)
 export spw=True # True or False (skip calculation of weights)
 export smy=False # True or False (skip make yaml)
-export scv=True # True or False (skip cut variation)
+export scv=True # True or False (skip cut variation), not used anymore
 export spm=True # True or False (skip projection for MC)
 export seff=True # True or False (skip efficiency)
 export svn=True # True or False (skip vn extraction)
 export sfcv=True # True or False (skip fraction by cut variation)
 export sddf=True # True or False (skip fraction by data-driven method)
 export sv2vf=True # True or False (skip v2 vs fraction)
+
+if [ $use_prep = False ]; then
+	export use_preprocessed=""
+else
+	export use_preprocessed="--preprocessed"
+fi
+
+if [ $sprep = False ]; then
+    export skip_pre_process=""
+else
+    export skip_pre_process="--skip_pre_process"
+fi
 
 if [ $spw = False ]; then
 	export skip_calc_weights=""
@@ -97,13 +111,14 @@ else
 	export skip_v2_vs_frac="--skip_v2_vs_frac"
 fi
 
-python3 run_cutvar.py $config_flow $anres_dir -c $cent -r $res_file -o $output_dir -s $suffix -vn $vn_method \
-						$skip_calc_weights \
-						$skip_make_yaml \
-						$skip_cut_variation \
-						$skip_proj_mc \
-						$skip_efficiency \
-						$skip_vn \
-						$skip_frac_cut_var \
-						$skip_data_driven_frac \
-						$skip_v2_vs_frac
+python3 run_cutvar.py $config_flow $anres_dir -c $cent -r $res_file -o $output_dir -s $suffix -vn $vn_method $use_preprocessed \
+					  $skip_pre_process \
+					  $skip_calc_weights \
+					  $skip_make_yaml \
+					  $skip_cut_variation \
+					  $skip_proj_mc \
+					  $skip_efficiency \
+					  $skip_vn \
+					  $skip_frac_cut_var \
+					  $skip_data_driven_frac \
+					  $skip_v2_vs_frac

--- a/run3/flow/BDT/sparse_dicts.py
+++ b/run3/flow/BDT/sparse_dicts.py
@@ -1,7 +1,7 @@
 import ROOT
 from ROOT import TFile
 
-def get_sparses(config, get_data, get_mc_reco, get_mc_gen, preprocessed=False, preprocess_dir=''):
+def get_sparses(config, get_data, get_mc_reco, get_mc_gen, preprocessed=False, preprocess_dir='', debug=False):
     
     sparsesFlow, sparsesReco, sparsesGen, axes_dict = {}, {}, {}, {}    
     
@@ -185,4 +185,14 @@ def get_sparses(config, get_data, get_mc_reco, get_mc_gen, preprocessed=False, p
         infiletask.Close()
 
     print(f"Loaded sparses!")
+    if debug:
+        print('\n')
+        print('###############################################################')
+        for key, value in axes_dict.items():
+            print(f"{key}:")
+            for sub_key, sub_value in value.items():
+                print(f"    {sub_key}: {sub_value}")
+        print('###############################################################')
+        print('\n')
+
     return sparsesFlow, sparsesReco, sparsesGen, axes_dict

--- a/run3/flow/compute_efficiency.py
+++ b/run3/flow/compute_efficiency.py
@@ -7,7 +7,7 @@ import os
 import numpy as np
 from ROOT import TFile, TCanvas, TH1F, TLegend, gROOT  # pylint: disable=import-error,no-name-in-module
 from flow_analysis_utils import get_centrality_bins
-### please fill your path of DmeasonAnalysis
+### please fill your path of DmesonAnalysis
 sys.path.append('../../../')
 from utils.StyleFormatter import SetGlobalStyle, SetObjectStyle
 from utils.AnalysisUtils import ComputeEfficiency
@@ -17,29 +17,21 @@ SetGlobalStyle(titleoffsety=1.1, maxdigits=3, topmargin=0.1,
                labelsizey=0.04, setoptstat=0, setopttitle=0,
                setdecimals=True, titleoffsetx=0.91, titlesizex=0.05)
 
-def check_cent_sel(charm_hadron, centclass, infile):
-    if charm_hadron in ['Dplus', 'Ds']:
-        cent_hist = infile.Get('hf-candidate-creator-3prong/hSelCollisionsCent')
-        _, centMinMax = get_centrality_bins(centclass)
-        for i in range(cent_hist.GetNbinsX()):
-            if not (cent_hist.GetBinContent(centMinMax[0] + 1) > 0 \
-                and cent_hist.GetBinContent(centMinMax[0]) == 0 \
-                and cent_hist.GetBinContent(centMinMax[1]) > 0 \
-                and cent_hist.GetBinContent(centMinMax[1] + 1) == 0):
-                print(f'\033[91mFATAL: Invalid centrality class: {centclass}. Exit!\033[0m')
-                sys.exit(1)
-    elif charm_hadron == 'Dzero':
-        cent_hist = infile.Get('hf-candidate-creator-2prong/hSelCollisionsCent')
-        _, centMinMax = get_centrality_bins(centclass)
-        for i in range(cent_hist.GetNbinsX()):
-            if not (cent_hist.GetBinContent(centMinMax[0] + 1) > 0 \
-                    and cent_hist.GetBinContent(centMinMax[0]) == 0 \
-                    and cent_hist.GetBinContent(centMinMax[1]) > 0 \
-                    and cent_hist.GetBinContent(centMinMax[1] + 1) == 0):
-                print(f'\033[91mFATAL: Invalid centrality class: {centclass}. Exit!\033[0m')
-                sys.exit(1)
-    else:
+def check_cent_sel(charm_hadron, centmin, centmax, infile):
+    if charm_hadron != 'Dzero' and charm_hadron != 'Dplus' and charm_hadron != 'Ds':
         print('\033[93mWARNING: Invalid charm hadron for centrality check.\033[0m')
+        sys.exit(1)
+
+    nprongs = 2 if charm_hadron == 'Dzero' else 3
+    cent_hist = infile.Get(f'hf-candidate-creator-{nprongs}prong/hSelCollisionsCent')
+    if cent_hist.GetBinContent(centmin + 1) == 0:
+        print(f'\033[93mWARNING: No entries in the first bin for centrality class: [{centmin}-{centmax}]!\033[0m')
+    if cent_hist.GetBinContent(centmin) != 0:
+        print(f'\033[93mWARNING: Non-empty bins for cent<{centmin}!\033[0m')
+    if cent_hist.GetBinContent(centmax) == 0:
+        print(f'\033[93mWARNING: No entries in the last bin for centrality class: [{centmin}-{centmax}]!\033[0m')
+    if cent_hist.GetBinContent(centmax + 1) != 0:
+        print(f'\033[93mWARNING: Non-empty bins for cent>{centmax}!\033[0m')
 
 def compute_eff(config_file, centclass, inputFile, outputdir, suffix):
     '''
@@ -72,7 +64,8 @@ def compute_eff(config_file, centclass, inputFile, outputdir, suffix):
 
     #_____________________________________________________________________________________
     # Check centrality selection
-    check_cent_sel(charm_hadron, centclass, infile)
+    centMin, centMax = get_centrality_bins(centclass)[1]
+    check_cent_sel(charm_hadron, centMin, centMax, infile)
 
     if charm_hadron == 'Dplus':
         gen_prompt_hist = infile.Get('hf-task-dplus/hPtGenPrompt')
@@ -180,10 +173,11 @@ def compute_eff_thns(config_file, centclass, inputFile, outputdir, suffix, batch
 
     #_____________________________________________________________________________________
     # Check centrality selection
-    check_cent_sel(charm_hadron, centclass, infile)
+    centMin, centMax = get_centrality_bins(centclass)[1]
+    check_cent_sel(charm_hadron, centMin, centMax, infile)
 
     #_____________________________________________________________________________________
-    # difne histograms
+    # define histograms
     hEffPrompt = TH1F('hEffPrompt', ';#it{p}_{T} (GeV/#it{c});Efficiency', nPtBins, np.asarray(ptLims, 'd'))
     hEffFD = TH1F('hEffFD', ';#it{p}_{T} (GeV/#it{c});Efficiency', nPtBins, np.asarray(ptLims, 'd'))
     hYieldPromptGen = TH1F('hYieldPromptGen', ';#it{p}_{T} (GeV/#it{c}); # Generated MC', nPtBins, np.asarray(ptLims, 'd'))

--- a/run3/flow/compute_efficiency.py
+++ b/run3/flow/compute_efficiency.py
@@ -203,10 +203,10 @@ def compute_eff_thns(config_file, centclass, inputFile, outputdir, suffix, batch
     for iPt, (ptMin, ptMax) in enumerate(zip(ptMins, ptMaxs)):
         ## get inpput histograms
         ## whether need to minus reflection from prompt or FD?
-        hRecoPrompt.append(infile.Get('hPromptPt_%0.f_%0.f' % (ptMin*10, ptMax*10)))
-        hRecoFD.append(infile.Get('hFDPt_%0.f_%0.f' % (ptMin*10, ptMax*10)))
-        hGenPrompt.append(infile.Get('hPromptGenPt_%0.f_%0.f' % (ptMin*10, ptMax*10)))
-        hGenFD.append(infile.Get('hFDGenPt_%0.f_%0.f' % (ptMin*10, ptMax*10)))
+        hRecoPrompt.append(infile.Get(f'cent_bins{centMin}_{centMax}/pt_bins{ptMin}_{ptMax}/hPromptPt'))
+        hRecoFD.append(infile.Get(f'cent_bins{centMin}_{centMax}/pt_bins{ptMin}_{ptMax}/hFDPt'))
+        hGenPrompt.append(infile.Get(f'cent_bins{centMin}_{centMax}/pt_bins{ptMin}_{ptMax}/hPromptGenPt'))
+        hGenFD.append(infile.Get(f'cent_bins{centMin}_{centMax}/pt_bins{ptMin}_{ptMax}/hFDGenPt'))
 
         ## load the values
         nRecoPromptUnc, nGenPromptUnc, nRecoFDUnc, nGenFDUnc = (ctypes.c_double() for _ in range(4))

--- a/run3/flow/flow_analysis_utils.py
+++ b/run3/flow/flow_analysis_utils.py
@@ -774,7 +774,7 @@ def get_particle_info(particleName):
 
     return particleTit, massAxisTit, decay, massForFit
 
-def get_cut_sets(pt_mins, pt_maxs, sig_cut, bkg_cut_maxs, correlated_cuts=True):
+def get_cut_sets(npt_bins, sig_cut, bkg_cut_maxs, correlated_cuts=True):
     '''
     Get cut sets
 
@@ -803,6 +803,7 @@ def get_cut_sets(pt_mins, pt_maxs, sig_cut, bkg_cut_maxs, correlated_cuts=True):
             list of lists of floats, list of upper edge for background cuts
     '''
     nCutSets = []
+    print(f"Number of pt bins: {npt_bins}")
     sig_cuts_lower, sig_cuts_upper, bkg_cuts_lower, bkg_cuts_upper = {}, {}, {}, {}
     if correlated_cuts:
         sig_cut_mins = sig_cut['min']
@@ -810,31 +811,31 @@ def get_cut_sets(pt_mins, pt_maxs, sig_cut, bkg_cut_maxs, correlated_cuts=True):
         sig_cut_steps = sig_cut['step']
 
         # compute the signal cutsets for each pt bin
-        sig_cuts_lower = [list(np.arange(sig_cut_mins[iPt], sig_cut_maxs[iPt], sig_cut_steps[iPt])) for iPt in range(len(pt_mins))]
-        sig_cuts_upper = [[1.0 for _ in range(len(sig_cuts_lower[iPt]))] for iPt in range(len(pt_mins))]
+        sig_cuts_lower = [list(np.arange(sig_cut_mins[iPt], sig_cut_maxs[iPt], sig_cut_steps[iPt])) for iPt in range(npt_bins)]
+        sig_cuts_upper = [[1.0 for _ in range(len(sig_cuts_lower[iPt]))] for iPt in range(npt_bins)]
 
         # compute the ncutsets by signal cut for each pt bin
-        nCutSets = [len(sig_cuts_lower[iPt]) for iPt in range(len(pt_mins))]
+        nCutSets = [len(sig_cuts_lower[iPt]) for iPt in range(npt_bins)]
 
         # bkg cuts lower edge should always be 0
-        bkg_cuts_lower = [[0. for _ in range(nCutSets[iPt])] for iPt in range(len(pt_mins))]
-        bkg_cuts_upper = [[bkg_cut_maxs[iPt] for _ in range(nCutSets[iPt])] for iPt in range(len(pt_mins))]
+        bkg_cuts_lower = [[0. for _ in range(nCutSets[iPt])] for iPt in range(npt_bins)]
+        bkg_cuts_upper = [[bkg_cut_maxs[iPt] for _ in range(nCutSets[iPt])] for iPt in range(npt_bins)]
 
     else:
         # load the signal cut
-        sig_cuts_lower = [sig_cut[iPt]['min'] for iPt in range(len(pt_mins))]
-        sig_cuts_upper = [sig_cut[iPt]['max'] for iPt in range(len(pt_mins))]
+        sig_cuts_lower = [sig_cut[iPt]['min'] for iPt in range(npt_bins)]
+        sig_cuts_upper = [sig_cut[iPt]['max'] for iPt in range(npt_bins)]
         
         # compute the ncutsets by the signal cut for each pt bin
-        nCutSets = [len(sig_cuts_lower[iPt]) for iPt in range(len(pt_mins))]
+        nCutSets = [len(sig_cuts_lower[iPt]) for iPt in range(npt_bins)]
         
         # load the background cut
-        bkg_cuts_lower = [[0. for _ in range(nCutSets[iPt])] for iPt in range(len(pt_mins))]
-        bkg_cuts_upper = [[bkg_cut_maxs[iPt] for _ in range(nCutSets[iPt])] for iPt in range(len(pt_mins))]
+        bkg_cuts_lower = [[0. for _ in range(nCutSets[iPt])] for iPt in range(npt_bins)]
+        bkg_cuts_upper = [[bkg_cut_maxs[iPt] for _ in range(nCutSets[iPt])] for iPt in range(npt_bins)]
         
     # safety check
 
-    for iPt in range(len(pt_mins)):
+    for iPt in range(npt_bins):
         assert len(sig_cuts_lower[iPt]) == len(sig_cuts_upper[iPt]) == len(bkg_cuts_lower[iPt]) == len(bkg_cuts_upper[iPt]) == nCutSets[iPt], \
             f"Mismatch in lengths for pt bin {iPt}: {len(sig_cuts_lower[iPt])}, {len(sig_cuts_upper[iPt])}, \
             {len(bkg_cuts_lower[iPt])}, {len(bkg_cuts_upper[iPt])}, \
@@ -873,4 +874,4 @@ def get_cut_sets_config(config):
         sig_cut = config['cut_variation']['uncorr_bdt_cut']['sig']
         bkg_cut_maxs = config['cut_variation']['uncorr_bdt_cut']['bkg_max']
 
-    return get_cut_sets(ptmins, ptmaxs, sig_cut, bkg_cut_maxs, correlated_cuts)
+    return get_cut_sets(len(ptmins), sig_cut, bkg_cut_maxs, correlated_cuts)

--- a/run3/flow/flow_analysis_utils.py
+++ b/run3/flow/flow_analysis_utils.py
@@ -803,7 +803,6 @@ def get_cut_sets(npt_bins, sig_cut, bkg_cut_maxs, correlated_cuts=True):
             list of lists of floats, list of upper edge for background cuts
     '''
     nCutSets = []
-    print(f"Number of pt bins: {npt_bins}")
     sig_cuts_lower, sig_cuts_upper, bkg_cuts_lower, bkg_cuts_upper = {}, {}, {}, {}
     if correlated_cuts:
         sig_cut_mins = sig_cut['min']

--- a/run3/flow/get_vn_vs_mass.py
+++ b/run3/flow/get_vn_vs_mass.py
@@ -60,7 +60,6 @@ def get_vn_vs_mass(fitConfigFileName, centClass, inFileName,
         massMaxs = [massMaxs] * len(ptMins)
     useRefl = fitConfig.get('InclRefl')
     reflFile = fitConfig.get('ReflFile', None)
-    useTemplates = fitConfig.get('IncludeKDETempls')
 
     # read fit configuration
     if not isinstance(fixSigma, list):
@@ -124,40 +123,42 @@ def get_vn_vs_mass(fitConfigFileName, centClass, inFileName,
             sys.exit()
 
     KDEtemplatesFuncts = []
-    KDEtemplates = [[None]*len(fitConfig['TemplsFlags']) for _ in range(len(ptMins))]
-    if useTemplates:
-        cTemplOverlap = [[None]*len(fitConfig['TemplsFlags']) for _ in range(len(ptMins))]
-        hRebinnedHistos = [[None]*len(fitConfig['TemplsFlags']) for _ in range(len(ptMins))]
-        templatesFile = TFile(f'{outputdir}/Templates.root', 'recreate')
-        for iPt in range(len(ptMins)):
-            for iFlag, flag in enumerate(fitConfig['TemplsFlags']):
-                if not fitConfig['IncludeKDETempls'][iPt]:
-                    KDEtemplates[iPt][iFlag], kde_func, hRebinnedHistos[iPt][iFlag], cTemplOverlap[iPt][iFlag] = None, None, None, None
-                    continue
-                elif fitConfig['IncludeKDETempls'][iPt] and fitConfig.get('FromGrid'):
-                    KDEtemplates[iPt][iFlag], kde_func, hRebinnedHistos[iPt][iFlag] = kde_producer(fitConfig['TemplsInputs'][iFlag], 'fM', ptMins[iPt], ptMaxs[iPt], flag,
-                                                                      templatesFile, fitConfig['TemplsTreeNames'][iFlag])
-                    templatesFile.cd()
-                    hRebinnedHistos[iPt][iFlag].Write(f"hBinned_pt_{iPt}")
-                    cTemplOverlap[iPt][iFlag] = TCanvas(f'cOverlap_{iPt}_{flag}', f'cOverlap_{iPt}_{flag}', 600, 600)
-                    cTemplOverlap[iPt][iFlag].cd()
-                    hRebinnedHistos[iPt][iFlag].Draw()
-                    kde_func.Draw('same')
-                    cTemplOverlap[iPt][iFlag].Write()
-                elif fitConfig['IncludeKDETempls'][iPt] and fitConfig.get('FromFile'):
-                    templFile = TFile.Open(f'{fitConfig["FromFile"]}', 'r')
-                    KDEtemplates[iPt][iFlag] = templFile.Get(f'KDE_pt_{ptMins[iPt]}_{ptMaxs[iPt]}_flag{flag}/KDEFunc_')
-                    hRebinnedHistos[iPt][iFlag] = templFile.Get(f'KDE_pt_{ptMins[iPt]}_{ptMaxs[iPt]}_flag{flag}/hBinned')
-                    templFile.Close()
-                    cTemplOverlap[iPt][iFlag] = TCanvas(f'cOverlap_{iPt}_{flag}', f'cOverlap_{iPt}_{flag}', 600, 600)
-                    cTemplOverlap[iPt][iFlag].cd()
-                    hRebinnedHistos[iPt][iFlag].Draw()
-                    kde_func.Draw('same')
-                else:
-                    print(f'ERROR: incorrect setting for including KDEs in fit! Exit!')
-                    sys.exit()
-        templatesFile.Close()
-        KDEtemplatesFuncts = [[KDE.GetFunction() if KDE is not None else None for KDE in KDEtemplatesPt] for KDEtemplatesPt in KDEtemplates]
+    for iPt, (bkgStr, sgnStr, bkgVnStr) in enumerate(zip(BkgFuncStr, SgnFuncStr, BkgFuncVnStr)):
+        useTemplates = fitConfig['IncludeKDETempls'][iPt] 
+        if useTemplates:
+            cTemplOverlap = [[None]*len(fitConfig['TemplsFlags']) for _ in range(len(ptMins))]
+            hRebinnedHistos = [[None]*len(fitConfig['TemplsFlags']) for _ in range(len(ptMins))]
+            KDEtemplates = [[None]*len(fitConfig['TemplsFlags']) for _ in range(len(ptMins))]
+            templatesFile = TFile(f'{outputdir}/Templates.root', 'recreate')
+            for iPt in range(len(ptMins)):
+                for iFlag, flag in enumerate(fitConfig['TemplsFlags']):
+                    if not fitConfig['IncludeKDETempls'][iPt]:
+                        KDEtemplates[iPt][iFlag], kde_func, hRebinnedHistos[iPt][iFlag], cTemplOverlap[iPt][iFlag] = None, None, None, None
+                        continue
+                    elif fitConfig['IncludeKDETempls'][iPt] and fitConfig.get('FromGrid'):
+                        KDEtemplates[iPt][iFlag], kde_func, hRebinnedHistos[iPt][iFlag] = kde_producer(fitConfig['TemplsInputs'][iFlag], 'fM', ptMins[iPt], ptMaxs[iPt], flag,
+                                                                            templatesFile, fitConfig['TemplsTreeNames'][iFlag])
+                        templatesFile.cd()
+                        hRebinnedHistos[iPt][iFlag].Write(f"hBinned_pt_{iPt}")
+                        cTemplOverlap[iPt][iFlag] = TCanvas(f'cOverlap_{iPt}_{flag}', f'cOverlap_{iPt}_{flag}', 600, 600)
+                        cTemplOverlap[iPt][iFlag].cd()
+                        hRebinnedHistos[iPt][iFlag].Draw()
+                        kde_func.Draw('same')
+                        cTemplOverlap[iPt][iFlag].Write()
+                    elif fitConfig['IncludeKDETempls'][iPt] and fitConfig.get('FromFile'):
+                        templFile = TFile.Open(f'{fitConfig["FromFile"]}', 'r')
+                        KDEtemplates[iPt][iFlag] = templFile.Get(f'KDE_pt_{ptMins[iPt]}_{ptMaxs[iPt]}_flag{flag}/KDEFunc_')
+                        hRebinnedHistos[iPt][iFlag] = templFile.Get(f'KDE_pt_{ptMins[iPt]}_{ptMaxs[iPt]}_flag{flag}/hBinned')
+                        templFile.Close()
+                        cTemplOverlap[iPt][iFlag] = TCanvas(f'cOverlap_{iPt}_{flag}', f'cOverlap_{iPt}_{flag}', 600, 600)
+                        cTemplOverlap[iPt][iFlag].cd()
+                        hRebinnedHistos[iPt][iFlag].Draw()
+                        kde_func.Draw('same')
+                    else:
+                        print(f'ERROR: incorrect setting for including KDEs in fit! Exit!')
+                        sys.exit()
+            templatesFile.Close()
+            KDEtemplatesFuncts = [[KDE.GetFunction() if KDE is not None else None for KDE in KDEtemplatesPt] for KDEtemplatesPt in KDEtemplates]
     
     # set particle configuration
     if particleName == 'Ds':

--- a/run3/flow/get_vn_vs_mass.py
+++ b/run3/flow/get_vn_vs_mass.py
@@ -182,7 +182,8 @@ def get_vn_vs_mass(fitConfigFileName, centClass, inFileName,
     hMCSgn, hMCRefl = [], []
     fMassTemplFuncts = [[None]*len(fitConfig['TemplsFlags']) for _ in range(len(ptMins))] if useTemplates else [] 
     fVnCompFuncts = [[None]*len(fitConfig['TemplsFlags']) for _ in range(len(ptMins))] if fitConfig.get('DrawVnComps') else []
-    hist_reso = infile.Get('histo_reso_delta_cent')
+    print(f"infile: {infile}")
+    hist_reso = infile.Get('hist_reso')
     hist_reso.SetDirectory(0)
     reso = hist_reso.GetBinContent(1)
     inclSecPeak = [inclSecPeak] * len(ptMins) if not isinstance(inclSecPeak, list) else inclSecPeak

--- a/run3/flow/project_thnsparse.py
+++ b/run3/flow/project_thnsparse.py
@@ -104,7 +104,7 @@ def check_anres(config, an_res_file, centrality, resolution, wagon_id,
     with alive_bar(len(pt_mins), title='Processing pt bins') as bar:
         # loop over pt bins
         for ipt, (pt_min, pt_max) in enumerate(zip(pt_mins, pt_maxs)):
-            outfile.mkdir(f'cent_bins{cent_min}_{cent_max}/pt_bins{int(pt_min*10)}_{int(pt_max*10)}')
+            outfile.mkdir(f'cent_bins{cent_min}_{cent_max}/pt_bins{pt_min}_{pt_max}')
             if use_preprocessed:
                 if config['apply_btd_cuts']:
                     thnsparse_selcent_list[ipt].GetAxis(axis_bdt_sig).SetRangeUser(sig_ml_cuts[ipt], 1)

--- a/run3/flow/project_thnsparse.py
+++ b/run3/flow/project_thnsparse.py
@@ -1,4 +1,5 @@
 import ROOT
+from ROOT import TFile
 import yaml
 import argparse
 import sys
@@ -6,8 +7,8 @@ import numpy as np
 from alive_progress import alive_bar
 from flow_analysis_utils import get_vn_versus_mass, get_centrality_bins, compute_r2, get_invmass_vs_deltaphi, get_occupancy, get_evselbits
 
-def check_anres(config, an_res_file, centrality, resolution,
-                wagon_id, outputdir, suffix, vn_method):
+def check_anres(config, an_res_file, centrality, resolution, wagon_id, 
+                outputdir, suffix, vn_method, use_preprocessed):
     with open(config, 'r') as ymlCfgFile:
         config = yaml.load(ymlCfgFile, yaml.FullLoader)
     # read configuration
@@ -60,41 +61,54 @@ def check_anres(config, an_res_file, centrality, resolution,
         bkg_ml_cuts = config['bkg_ml_cuts']
         sig_ml_cuts = config['sig_ml_cuts']
 
-    # load input file
-    thnsparse_list, thnsparse_selcent_list, thnsparse_selcents = [], [], []
-    for file in an_res_file:
-        infile = ROOT.TFile(file, 'READ')
-        if wagon_id != '':
-            wagon_id = f'_id{wagon_id}'
-        thnsparse_list.append(infile.Get(f'hf-task-flow-charm-hadrons{wagon_id}/hSparseFlowCharm'))
-        if not thnsparse_list[-1]:
-            sys.exit(f'\033[91m FATAL: Could not find thnsparse in {an_res_file}\033[0m')
-
-    # sanity check of the pt bins
-    bin_edges = [thnsparse_list[-1].GetAxis(axis_pt).GetBinLowEdge(bin) for bin in range(1, thnsparse_list[-1].GetAxis(axis_pt).GetNbins() + 1)]
-    bin_edges.append(thnsparse_list[-1].GetAxis(axis_pt).GetBinUpEdge(thnsparse_list[-1].GetAxis(axis_pt).GetNbins()))
-    if any(pt_min not in bin_edges or pt_max not in bin_edges for pt_min, pt_max in zip(pt_mins, pt_maxs)):
-        sys.exit('\033[91m FATAL: Too granular pt bins, pt_min or pt_max not in the bin edges\033[0m')
-
     # output file
     outfile = ROOT.TFile(f'{outputdir}/proj{suffix}.root', 'RECREATE')
     hist_reso = ROOT.TH1F('hist_reso', 'hist_reso', len(cent_bins) - 1, cent_bins[0], cent_bins[-1])
     cent_min = cent_bins[0]
     cent_max = cent_bins[1]
-    for thnssparse in thnsparse_list:
-        thnsparse_selcent_list.append(thnssparse.Clone(f'thnsparse_selcent{cent_min}_{cent_max}'))
-        thnsparse_selcent_list[-1].GetAxis(axis_cent).SetRangeUser(cent_min, cent_max)
     hist_reso.SetBinContent(hist_reso.FindBin(cent_min), reso)
     vn_axis = axis_sp if vn_method == 'sp' else axis_deltaphi
     if use_inv_mass_bins:
         inv_mass_bins = [[] for _ in range(len(pt_mins))]
 
+    # load input file
+    thnsparse_list, thnsparse_selcent_list, thnsparse_selcents = [], [], []
+    if use_preprocessed:
+        for ipt, (pt_min, pt_max) in enumerate(zip(pt_mins, pt_maxs)):
+            infile = TFile.Open(f"{config['skimDir']}/AnalysisResults_pt_{int(pt_min*10)}_{int(pt_max*10)}.root", 'r')
+            thnsparse_selcent_list.append(infile.Get(f'hf-task-flow-charm-hadrons/hSparseFlowCharm'))
+            infile.Close()
+        axis_bdt_sig = config['axestokeep'].index('score_FD')
+        axis_sp = config['axestokeep'].index('sp')
+        axis_mass = config['axestokeep'].index('Mass')
+        vn_axis = axis_sp if vn_method == 'sp' else vn_axis
+    else:
+        for file in an_res_file:
+            infile = ROOT.TFile(file, 'READ')
+            if wagon_id != '':
+                wagon_id = f'_id{wagon_id}'
+            thnsparse_list.append(infile.Get(f'hf-task-flow-charm-hadrons{wagon_id}/hSparseFlowCharm'))
+            if not thnsparse_list[-1]:
+                sys.exit(f'\033[91m FATAL: Could not find thnsparse in {an_res_file}\033[0m')
+
+        # sanity check of the pt bins
+        bin_edges = [thnsparse_list[-1].GetAxis(axis_pt).GetBinLowEdge(bin) for bin in range(1, thnsparse_list[-1].GetAxis(axis_pt).GetNbins() + 1)]
+        bin_edges.append(thnsparse_list[-1].GetAxis(axis_pt).GetBinUpEdge(thnsparse_list[-1].GetAxis(axis_pt).GetNbins()))
+        if any(pt_min not in bin_edges or pt_max not in bin_edges for pt_min, pt_max in zip(pt_mins, pt_maxs)):
+            sys.exit('\033[91m FATAL: Too granular pt bins, pt_min or pt_max not in the bin edges\033[0m')
+
+        for thnsparse in thnsparse_list:
+            thnsparse_selcent_list.append(thnsparse.Clone(f'thnsparse_selcent{cent_min}_{cent_max}'))
+            thnsparse_selcent_list[-1].GetAxis(axis_cent).SetRangeUser(cent_min, cent_max)
+
     with alive_bar(len(pt_mins), title='Processing pt bins') as bar:
         # loop over pt bins
         for ipt, (pt_min, pt_max) in enumerate(zip(pt_mins, pt_maxs)):
-            outfile.mkdir(f'cent_bins{cent_min}_{cent_max}/pt_bins{pt_min}_{pt_max}')
-            for iThn, thnsparse_selcent in enumerate(thnsparse_selcent_list):
-                thnsparse_selcent.GetAxis(axis_pt).SetRangeUser(pt_min, pt_max)
+            outfile.mkdir(f'cent_bins{cent_min}_{cent_max}/pt_bins{int(pt_min*10)}_{int(pt_max*10)}')
+            if use_preprocessed:
+                if config['apply_btd_cuts']:
+                    thnsparse_selcent_list[ipt].GetAxis(axis_bdt_sig).SetRangeUser(sig_ml_cuts[ipt], 1)
+                thnsparse_selcents = [thnsparse_selcent_list[ipt]]
                 if use_inv_mass_bins:
                     inv_mass_bins_ipt = []
                     rebin = config['Rebin'][ipt]
@@ -107,12 +121,27 @@ def check_anres(config, an_res_file, centrality, resolution,
                     del hmass_dummy
                     inv_mass_bins[ipt] = inv_mass_bins_ipt
                 inv_mass_bin = inv_mass_bins[ipt]
-                # apply BDT cuts (TODO: save the bdt score distribution after the cuts in the output file)
-                if apply_btd_cuts:
-                    print('\033[93m WARNING: Applying BDT cuts\033[0m')
-                    thnsparse_selcent.GetAxis(axis_bdt_bkg).SetRangeUser(0, bkg_ml_cuts[ipt])
-                    thnsparse_selcent.GetAxis(axis_bdt_sig).SetRangeUser(sig_ml_cuts[ipt], 1)
-                thnsparse_selcents.append(thnsparse_selcent)
+            else:
+                for iThn, thnsparse_selcent in enumerate(thnsparse_selcent_list):
+                    thnsparse_selcent.GetAxis(axis_pt).SetRangeUser(pt_min, pt_max)
+                    if use_inv_mass_bins:
+                        inv_mass_bins_ipt = []
+                        rebin = config['Rebin'][ipt]
+                        hmass_dummy = thnsparse_selcent.Projection(axis_mass)
+                        hmass_dummy = hmass_dummy.Rebin(rebin, f'hmass_dummy_{ipt}')
+                        for ibin in range(1, hmass_dummy.GetNbinsX() + 1):
+                            inv_mass_bins_ipt.append(hmass_dummy.GetBinLowEdge(ibin))
+                            if ibin == hmass_dummy.GetNbinsX():
+                                inv_mass_bins_ipt.append(hmass_dummy.GetBinLowEdge(ibin) + hmass_dummy.GetBinWidth(ibin))
+                        del hmass_dummy
+                        inv_mass_bins[ipt] = inv_mass_bins_ipt
+                    inv_mass_bin = inv_mass_bins[ipt]
+                    # apply BDT cuts (TODO: save the bdt score distribution after the cuts in the output file)
+                    if apply_btd_cuts:
+                        print('\033[93m WARNING: Applying BDT cuts\033[0m')
+                        thnsparse_selcent.GetAxis(axis_bdt_bkg).SetRangeUser(0, bkg_ml_cuts[ipt])
+                        thnsparse_selcent.GetAxis(axis_bdt_sig).SetRangeUser(sig_ml_cuts[ipt], 1)
+                    thnsparse_selcents.append(thnsparse_selcent)
                     
             # create output histograms
             outfile.cd(f'cent_bins{cent_min}_{cent_max}/pt_bins{pt_min}_{pt_max}')
@@ -136,7 +165,7 @@ def check_anres(config, an_res_file, centrality, resolution,
                 if reso > 0:
                     hist_vn.Scale(1./reso)
                     hist_vn.Write()
-                for iThn, thnsparse_selcent in enumerate(thnsparse_selcent_list):
+                for iThn, thnsparse_selcent in enumerate(thnsparse_selcents):
                     hist_mass_temp = thnsparse_selcent.Projection(axis_mass)
                     hist_mass_temp.SetName(f'hist_mass_cent{cent_min}_{cent_max}_pt{pt_min}_{pt_max}_{iThn}')
                     if iThn == 0:
@@ -171,9 +200,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Arguments")
     parser.add_argument("config", metavar="text",
                         default="config.yaml", help="configuration file")
-    # parser.add_argument("an_res_file", metavar="text",
-    #                     default="an_res.root", help="input ROOT file with anres")
-    parser.add_argument('an_res_file', metavar='text', 
+    parser.add_argument('an_res_file', metavar='file.root', 
                         nargs='+', help='input ROOT files with anres')
     parser.add_argument("--centrality", "-c", metavar="text",
                         default="k3050", help="centrality class")
@@ -187,6 +214,8 @@ if __name__ == "__main__":
                         default="", help="suffix for output files")
     parser.add_argument("--vn_method", "-vn", metavar="text",
                         default="sp", help="vn technique (sp, ep, deltaphi)")
+    parser.add_argument('--preprocessed', action='store_true', 
+                        help='Determines whether the sparses are pre-processed')
     args = parser.parse_args()
 
     check_anres(
@@ -197,5 +226,6 @@ if __name__ == "__main__":
         wagon_id=args.wagon_id,
         outputdir=args.outputdir,
         suffix=args.suffix,
-        vn_method=args.vn_method
+        vn_method=args.vn_method,
+        use_preprocessed=args.preprocessed
     )

--- a/run3/flow/run_full_flow_analysis.py
+++ b/run3/flow/run_full_flow_analysis.py
@@ -17,6 +17,8 @@ def run_full_analysis(config,
                       skip_projection,
                       skip_vn,
                       skip_efficiency,
+                      skip_preprocess,
+                      inputspreprocessed,
                       batch
                       ):
     """
@@ -37,6 +39,8 @@ def run_full_analysis(config,
     - skip_projection (bool): skip projection extraction
     - skip_vn (bool): skip raw yield extraction
     - skip_efficiency (bool): skip efficiency estimation
+    - preprocess (bool): preprocess inputs, flag --skip_preprocess in bash script
+    - inputspreprocessed (bool): take preprocessed files as inputs
     - batch (bool): suppress video output
     """
 
@@ -56,7 +60,7 @@ def run_full_analysis(config,
     cent_withopt = f" -c {centrality}"
     wagon_id_withopt = f" -w {wagon_id}"
 
-    if skip_resolution and skip_projection and skip_vn:
+    if skip_resolution and skip_projection and skip_vn and skip_preprocess:
         print("\033[91m Nothing to do, all steps are skipped\033[0m")
         return
 
@@ -82,6 +86,13 @@ def run_full_analysis(config,
         print(f"\033[92m {command_reso}\033[0m")
         os.system(command_reso)
 
+    # preprocess the AnalysisResults.root files
+    if not skip_preprocess:
+        inputspreprocessed = True
+        os.system(f"python3 {os.path.join(script_dir, '../tool/pre_process.py')} {config} {outputdir} --pre -s {suffix}")
+    else:
+        print("\033[33mWARNING: Pre-process will not be performed\033[0m")
+
     if not skip_projection:
         # projection
         if not os.path.exists(f"{outputdir}/proj"):
@@ -96,7 +107,8 @@ def run_full_analysis(config,
         reso_file_withopt = f" -r {reso_file}"
         outputdir_proj = f"-o {outputdir}/proj"
         an_res_files = " ".join(an_res_file)
-        command_proj = f"python3 {os.path.join(script_dir, 'project_thnsparse.py')} {config} {an_res_files} {cent_withopt} {reso_file_withopt} {suffix_withopt} {outputdir_proj} {vn_method_withopt}"
+        pre_process = "--preprocessed" if inputspreprocessed else ""
+        command_proj = f"python3 {os.path.join(script_dir, 'project_thnsparse.py')} {config} {an_res_files} {cent_withopt} {reso_file_withopt} {suffix_withopt} {outputdir_proj} {vn_method_withopt} {pre_process}"
         if wagon_id != "":
             command_proj += f" {wagon_id_withopt}"
         print("\n\033[92m Starting projection\033[0m")
@@ -161,6 +173,10 @@ if __name__ == "__main__":
                         help="skip vn estimation")
     parser.add_argument("--skip_efficiency", action="store_true", default=False,
                         help="skip efficiency estimation")
+    parser.add_argument("--skip_preprocess", "-prep", action="store_true", default=False,
+                        help="preprocess inputs")
+    parser.add_argument("--inputspreprocessed", "-inputsprep", action="store_true", 
+                        help="use preprocessed input")
     parser.add_argument("--batch", action="store_true", default=False,
                         help="suppress video output")
     args = parser.parse_args()
@@ -178,5 +194,7 @@ if __name__ == "__main__":
         args.skip_projection,
         args.skip_vn,
         args.skip_efficiency,
+        args.skip_preprocess,
+        args.inputspreprocessed,
         args.batch
     )


### PR DESCRIPTION
With this PR, the following changes are introduced:
- the sparse structure encoded in the `sparse_dicts.py` script is exploited to perform the projections
- projections of data and mc sparses are performed together in the script `proj_thn_mc.py`, looping over the cutsets. The script `cut_variation.py` is not needed anymore. Moreover, the projections over mass and pt are explicitly mentioned for clarity. A remaining improvement would be to apply the pt weights for the generated mc once, maybe in the pt_weights script, since they are cut-independent.
- improvements in the saving of histograms, with folder structure based on pt bins