### PR TITLE
Patch: correct the method of  `fixSigma`

### DIFF
--- a/run3/flow/get_vn_vs_mass.py
+++ b/run3/flow/get_vn_vs_mass.py
@@ -406,7 +406,7 @@ def get_vn_vs_mass(fitConfigFileName, centClass, inFileName,
             # Sigma
             vnFitter[iPt].SetInitialGaussianSigma(fitConfig['Sigma'][iPt], 1)
             if fixSigma[iPt]:
-                vnFitter[iPt].FixSigmaFromMassFit()
+                vnFitter[iPt].SetInitialGaussianSigma(fitConfig['Sigma'][iPt], 2)
             # nSigma4SB
             if 'NSigma4SB' in fitConfig:
                 vnFitter[iPt].SetNSigmaForVnSB(fitConfig['NSigma4SB'][iPt])
@@ -420,9 +420,9 @@ def get_vn_vs_mass(fitConfigFileName, centClass, inFileName,
             if secPeak and particleName == 'Dplus':
                 vnFitter[iPt].IncludeSecondGausPeak(massDstar, False, fitConfig['SigmaSecPeak'][iPt], False, 1, fitConfig.get('FixVnSecPeakToSgn', False))
                 if fixSigma[iPt]:
-                    vnFitter[iPt].FixSigma2GausFromMassFit()
+                    vnFitter[iPt].SetFixSecondGaussianSigma(fitConfig['SigmaSecPeak'][iPt], 2)
             vnFitter[iPt].FixFrac2GausFromMassFit()
-            # TODO: Add reflections for D0
+
             # Reflections for D0
             if useRefl:
                 SoverR = (hMCRefl[iPt].Integral(hMCRefl[iPt].FindBin(massMin*1.0001),hMCRefl[iPt].FindBin(massMax*0.9999)))/(


### PR DESCRIPTION
Hi @Marcellocosti and @stefanopolitano ! There is a method that makes me confused, so I would like to point it out and have a discussion with you.
Did we correctly fix the Sigma? 
Sometimes, I find that if I fix the Sigma from the file (the feature from my brunch, but the method used to 'fix Sigma' is the same), the fitting output shows that the Sigma was fixed, but it isn't the value I want to set.
So, I had a look at the code of the fitter, I found that at https://github.com/DmesonAnalysers/DmesonAnalysis/blob/419bb3f5ab535cb9b5362e099800f6b944296e94/run3/flow/invmassfitter/VnVsMassFitter.h#L31 and https://github.com/DmesonAnalysers/DmesonAnalysis/blob/419bb3f5ab535cb9b5362e099800f6b944296e94/run3/flow/invmassfitter/VnVsMassFitter.h#L33,  we provide the initial sigma and the option used to deciding to fix the sigma or not. And 1 means do not fix, 2 means fix the sigma based on the initial value.

It first fixed the sigma in [1]
``` 
if(fSigmaFixed==1) fMassFitter->SetInitialGaussianSigma(fSigmaInit);
else if(fSigmaFixed==2) fMassFitter->SetFixGaussianSigma(fSigmaInit);
```
for mass pre-fit, then inherited in [2]
```
  if(fSigmaFixed==2 || fSigmaFixedFromMassFit) {fitter.Config().ParSettings(fNParsMassBkg+2).Fix();}
  if(fMassSgnFuncType==k2Gaus) {
    if(fFrac2GausFixed==2 || fFrac2GausFixedFromMassFit) {fitter.Config().ParSettings(fNParsMassBkg+3).Fix();}
    if(fSigma2GausFixed==2 || fSigma2GausFixedFromMassFit) {fitter.Config().ParSettings(fNParsMassBkg+4).Fix();}
  }
``` 
(since the sigma in pre-fit has been fixed, so here the sigma is the initial value). For the 2gaus, the code is similar. 
But I am not familiar with it, so I am not sure whether the https://github.com/DmesonAnalysers/DmesonAnalysis/blob/419bb3f5ab535cb9b5362e099800f6b944296e94/run3/flow/get_vn_vs_mass.py#L424 is the method you want, then I didn't modify it.

And actually, https://github.com/DmesonAnalysers/DmesonAnalysis/blob/419bb3f5ab535cb9b5362e099800f6b944296e94/run3/flow/invmassfitter/VnVsMassFitter.h#L39 only means fix the sigma from the mass pre-fit. 

Please let me know if there is something that isn't clear, or if I errorly understand.

[1]. https://github.com/DmesonAnalysers/DmesonAnalysis/blob/419bb3f5ab535cb9b5362e099800f6b944296e94/run3/flow/invmassfitter/VnVsMassFitter.cxx#L591C1-L592C72 
[2]. https://github.com/DmesonAnalysers/DmesonAnalysis/blob/419bb3f5ab535cb9b5362e099800f6b944296e94/run3/flow/invmassfitter/VnVsMassFitter.cxx#L310C1-L310C101
 