### PR TITLE
Parallelize projections

### DIFF
--- a/run3/flow/BDT/ComputeDataDriFrac_flow.py
+++ b/run3/flow/BDT/ComputeDataDriFrac_flow.py
@@ -141,35 +141,37 @@ def load_eff_histos(effFiles):
         hFDFracCorrs[-1].SetDirectory(0)
     return hEffPrompts, hEffFDs, hPromptFracs, hFDFracs, hPromptFracCorrs, hFDFracCorrs
 
-def load_eff_files(inputdir, suffix):
+def load_eff_files(inputdir):
     if os.path.exists(f'{inputdir}/eff'):
+        print(f'Loading {inputdir}/eff')
         effFiles = [f'{inputdir}/eff/{file}'
-                        for file in os.listdir(f'{inputdir}/eff') if file.endswith('.root') and suffix in file]
+                        for file in os.listdir(f'{inputdir}/eff') if file.endswith('.root')]
         effFiles.sort()
     else:
-        raise ValueError(f'No eff fodel found in {inputdir}')
+        raise ValueError(f'No eff folder found in {inputdir}')
     return effFiles
 
-def load_cutVarFrac_files(inputdir, suffix):
+def load_cutVarFrac_files(inputdir):
     if os.path.exists(f'{inputdir}/CutVarFrac'):
-        cutVarFracFiles = [f'{inputdir}/CutVarFrac/{file}' 
-                        for file in os.listdir(f'{inputdir}/CutVarFrac') if file.endswith('.root') and suffix in file]
+        print(f'Loading {inputdir}/CutVarFrac')
+        cutVarFracFiles = [f'{inputdir}/CutVarFrac/{file}'
+                        for file in os.listdir(f'{inputdir}/CutVarFrac') if file.endswith('.root')]
         cutVarFracFiles.sort()
     else:
         raise ValueError(f'No CutVarFrac folder found in {inputdir}')
     return cutVarFracFiles
 
 def main_data_driven_frac(inputdir, outputdir, suffix, batch, combined=False, correlatedCutVarPath="", outputdir_combined=""):
-    
+
     if batch:
         gROOT.SetBatch()
-        
-    effFiles = load_eff_files(inputdir, suffix)
+
+    effFiles = load_eff_files(inputdir)
     hEffPrompts, hEffFDs, hPromptFracs, hFDFracs, hPromptFracCorrs, hFDFracCorrs = load_eff_histos(effFiles)
-    
-    cutVarFracFiles = load_cutVarFrac_files(inputdir, suffix)
+
+    cutVarFracFiles = load_cutVarFrac_files(inputdir)
     hCorrYieldPrompt, hCorrYieldFD, hCovPromptPrompt, hCovPromptFD, hCovFDFD = load_cutVarFrac_histos(cutVarFracFiles)
-    
+
     for iFile in range(len(effFiles)):
         data_driven_frac(
             outputdir,
@@ -187,9 +189,9 @@ def main_data_driven_frac(inputdir, outputdir, suffix, batch, combined=False, co
             hCovPromptFD,
             hCovFDFD
         )
-        
     if combined:
-        cutVarFracFiles = load_cutVarFrac_files(correlatedCutVarPath, suffix)
+        print('Computing combined DataDriFrac')
+        cutVarFracFiles = load_cutVarFrac_files(correlatedCutVarPath)
         hCorrYieldPrompt, hCorrYieldFD, hCovPromptPrompt, hCovPromptFD, hCovFDFD = load_cutVarFrac_histos(cutVarFracFiles)
         
         for iFile in range(len(effFiles)):

--- a/run3/flow/BDT/compute_frac_cut_var.py
+++ b/run3/flow/BDT/compute_frac_cut_var.py
@@ -5,65 +5,25 @@ import os
 import numpy as np
 from itertools import product
 import ROOT
-from ROOT import TFile, TCanvas, TLegend, TLatex, gROOT
-from ROOT import TFile, TH1F, TH2F, TCanvas, TLegend, TGraphAsymmErrors, TLatex, gRandom, TF1  # pylint: disable=import-error,no-name-in-module
+from ROOT import TFile, TCanvas, TLegend, TLatex, gROOT, gStyle
+from ROOT import TFile, TH1F, TH2F, TCanvas, TLegend, TLatex, gRandom  # pylint: disable=import-error,no-name-in-module
 from ROOT import kBlack, kRed, kAzure, kGreen, kRainBow # pylint: disable=import-error,no-name-in-module
-from ROOT import kFullCircle, kFullSquare, kOpenSquare, kOpenCircle, kOpenCross, kOpenDiamond # pylint: disable=import-error,no-name-in-module
+from ROOT import kFullCircle, kFullSquare, kOpenSquare, kOpenCircle # pylint: disable=import-error,no-name-in-module
 from os.path import exists
 sys.path.append('../../../')
 sys.path.append('..')
 from flow_analysis_utils import get_cut_sets_config
 from utils.StyleFormatter import SetGlobalStyle, SetObjectStyle
-from utils.AnalysisUtils import GetPromptFDYieldsAnalyticMinimisation, ApplyVariationToList
+from utils.AnalysisUtils import GetPromptFDYieldsAnalyticMinimisation
 
-def compute_frac_cut_var(config_flow, inputdir, outputdir, suffix, batch=False):
+def minimise_chi2(config, ptmins, ptmaxs, hRawYields, hEffPrompt, hEffFD, outputdir, suffix, systematics):
 
-    gROOT.SetBatch(batch)
+    hRawYieldsVsCut, hRawYieldsVsCutReSum, hRawYieldPromptVsCut, hRawYieldFDVsCut = [], [], [], []
+    hEffPromptVsCut, hEffFDVsCut = [], []
+    hPromptFracVsCut, hFDFracVsCut = [], []
+    hCorrMatrixCutSets = []
+    cFinalResPt = []
 
-    CutSets, _, _, _, _ = get_cut_sets_config(config_flow)
-    nCutSets = max(CutSets)
-    with open(config_flow, 'r') as ymlCfgFile:
-        config = yaml.load(ymlCfgFile, yaml.FullLoader)
-
-    if os.path.exists(f'{inputdir}/eff'):
-        effFiles = [f'{inputdir}/eff/{file}'
-                    for file in os.listdir(f'{inputdir}/eff') if file.endswith('.root') and suffix in file]
-    else:
-        raise ValueError(f'No eff fodel found in {inputdir}')
-    
-    if os.path.exists(f'{inputdir}/ry'):
-        rawYieldFiles = [f'{inputdir}/ry/{file}' 
-                        for file in os.listdir(f'{inputdir}/ry') if file.endswith('.root') and suffix in file]
-    else:
-        raise ValueError(f'No ry folder found in {inputdir}')
-    
-    effFiles.sort()
-    rawYieldFiles.sort()
-
-    # load configuration
-    ptmins = config['ptmins']
-    ptmaxs = config['ptmaxs']
-
-    #TODO: apply smearing
-
-    hRawYields, hEffPrompt, hEffFD = [], [], []
-
-    # load inputs raw yields and efficiencies
-    hCrossSecPrompt, hCrossSecFD = [], []
-
-    for inFileNameRawYield, inFileNameEff in zip(rawYieldFiles, effFiles):
-
-        inFileRawYield = ROOT.TFile.Open(inFileNameRawYield)
-        hRawYields.append(inFileRawYield.Get('hRawYieldsSimFit'))
-        hRawYields[-1].SetDirectory(0)
-        
-        inFileEff = TFile.Open(inFileNameEff)
-        hEffPrompt.append(inFileEff.Get('hEffPrompt'))
-        hEffFD.append(inFileEff.Get('hEffFD'))
-        hEffPrompt[-1].SetDirectory(0)
-        hEffFD[-1].SetDirectory(0)
-
-    # create output histograms
     hCorrYieldPrompt = hRawYields[0].Clone('hCorrYieldPrompt')
     hCorrYieldPrompt.SetTitle(';#it{p}_{T} (GeV/#it{c}); #it{N}_{prompt}')
     SetObjectStyle(hCorrYieldPrompt, color=kRed+1, fillcolor=kRed+1, markerstyle=kFullCircle)
@@ -74,7 +34,7 @@ def compute_frac_cut_var(config_flow, inputdir, outputdir, suffix, batch=False):
 
     hCovCorrYields = [[hRawYields[0].Clone('hCovPromptPrompt'), hRawYields[0].Clone('hCovPromptFD')],
                     [hRawYields[0].Clone('hCovFDPrompt'), hRawYields[0].Clone('hCovFDFD')]]
-    
+
     for iRow, row in enumerate(hCovCorrYields):
         for iCol, hCov in enumerate(row):
             SetObjectStyle(hCov, linecolor=kBlack)
@@ -88,49 +48,68 @@ def compute_frac_cut_var(config_flow, inputdir, outputdir, suffix, batch=False):
                 colName = '#it{N}_{non-prompt}'
             hCov.SetTitle(f';#it{{p}}_{{T}} (GeV/#it{{c}}); #sigma({rowName}, {colName})')
 
-    SetGlobalStyle(padleftmargin=0.15, padtopmargin=0.08, titleoffsetx=1.,
-                titleoffsety=1.4, opttitle=1, palette=kRainBow, maxdigits=2)
-
-    legDistr = TLegend(0.45, 0.69, 0.75, 0.89)
-    legDistr.SetFillStyle(0)
-    legDistr.SetBorderSize(0)
-    legDistr.SetTextSize(0.045)
-
-    legEff = TLegend(0.2, 0.2, 0.4, 0.4)
-    legEff.SetFillStyle(0)
-    legEff.SetBorderSize(0)
-    legEff.SetTextSize(0.045)
-
-    legFrac = TLegend(0.2, 0.79, 0.4, 0.89)
-    legFrac.SetFillStyle(0)
-    legFrac.SetBorderSize(0)
-    legFrac.SetTextSize(0.045)
-
-    latInfo = TLatex()
-    latInfo.SetNDC()
-    latInfo.SetTextSize(0.045)
-    latInfo.SetTextFont(42)
-    latInfo.SetTextColor(1)
-
-    hRawYieldsVsCut, hRawYieldsVsCutReSum, hRawYieldPromptVsCut, hRawYieldFDVsCut, cDistr = [], [], [], [], []
-    hEffPromptVsCut, hEffFDVsCut, cEff = [], [], []
-    hPromptFracVsCut, hFDFracVsCut, gPromptFracFcVsCut, gFDFracFcVsCut, gPromptFracNbVsCut, \
-    gFDFracNbVsCut, cFrac = [], [], [], [], [], [], []
-    hCorrMatrixCutSets, cCorrMatrix = [], []
-
     for iPt, (ptMin, ptMax) in enumerate(zip(ptmins, ptmaxs)):
-        nSets = CutSets[iPt]
+        listRawYield, listRawYieldUnc, listEffPrompt,\
+        listEffPromptUnc, listEffFD, listEffFDUnc = ([] for i in range(6))
 
-        listRawYield = [hRaw.GetBinContent(iPt+1) for hRaw in hRawYields[:nSets]]
-        listRawYieldUnc = [hRaw.GetBinError(iPt+1) for hRaw in hRawYields[:nSets]]
-        listEffPrompt = [hEffP.GetBinContent(iPt+1) for hEffP in hEffPrompt[:nSets]]
-        listEffPromptUnc = [hEffP.GetBinError(iPt+1) for hEffP in hEffPrompt[:nSets]]
-        listEffFD = [hEffF.GetBinContent(iPt+1) for hEffF in hEffFD[:nSets]]
-        listEffFDUnc = [hEffF.GetBinError(iPt+1) for hEffF in hEffFD[:nSets]]
+        for iCut, (hRaw, hEffP, hEffF) in enumerate(zip(hRawYields, hEffPrompt, hEffFD)):
+            # if skip_cuts is defined check if the cut number is present for that pt
+            if 'skip_cuts' in config['minimisation']:
+                if iCut in config['minimisation']['skip_cuts'][iPt]:
+                    print(f'Skipping cut set {iCut} for pt {ptMin:.1f}-{ptMax:.1f}')
+                    continue
+            listRawYield.append(hRaw.GetBinContent(iPt+1))
+            listRawYieldUnc.append(hRaw.GetBinError(iPt+1))
+            listEffPrompt.append(hEffP.GetBinContent(iPt+1))
+            listEffPromptUnc.append(hEffP.GetBinError(iPt+1))
+            listEffFD.append(hEffF.GetBinContent(iPt+1))
+            listEffFDUnc.append(hEffF.GetBinError(iPt+1))
 
+        if systematics:
+            if systematics == 'minus3low' or systematics == 'minus3':
+                listRawYield     = [x for i, x in enumerate(listRawYield) if i < 3]
+                listRawYieldUnc  = [x for i, x in enumerate(listRawYieldUnc) if i < 3]
+                listEffPrompt    = [x for i, x in enumerate(listEffPrompt) if i < 3]
+                listEffPromptUnc = [x for i, x in enumerate(listEffPromptUnc) if i < 3]
+                listEffFD        = [x for i, x in enumerate(listEffFD) if i < 3]
+                listEffFDUnc     = [x for i, x in enumerate(listEffFDUnc) if i < 3]
+            if systematics == 'minus3high' or systematics == 'minus3':
+                listRawYield     = [x for i, x in enumerate(listRawYield) if i > len(listRawYield) - 3]
+                listRawYieldUnc  = [x for i, x in enumerate(listRawYieldUnc) if i > len(listRawYield) - 3]
+                listEffPrompt    = [x for i, x in enumerate(listEffPrompt) if i > len(listRawYield) - 3]
+                listEffPromptUnc = [x for i, x in enumerate(listEffPromptUnc) if i > len(listRawYield) - 3]
+                listEffFD        = [x for i, x in enumerate(listEffFD) if i > len(listRawYield) - 3]
+                listEffFDUnc     = [x for i, x in enumerate(listEffFDUnc) if i > len(listRawYield) - 3]
+            # Remove even-indexed elements if 'even' is in systematics
+            if 'even' in systematics:
+                listRawYield     = [x for i, x in enumerate(listRawYield) if i % 2 != 0]
+                listRawYieldUnc  = [x for i, x in enumerate(listRawYieldUnc) if i % 2 != 0]
+                listEffPrompt    = [x for i, x in enumerate(listEffPrompt) if i % 2 != 0]
+                listEffPromptUnc = [x for i, x in enumerate(listEffPromptUnc) if i % 2 != 0]
+                listEffFD        = [x for i, x in enumerate(listEffFD) if i % 2 != 0]
+                listEffFDUnc     = [x for i, x in enumerate(listEffFDUnc) if i % 2 != 0]
+            # Remove odd-indexed elements if 'odd' is in systematics
+            if 'odd' in systematics:
+                listRawYield     = [x for i, x in enumerate(listRawYield) if i % 2 == 0]
+                listRawYieldUnc  = [x for i, x in enumerate(listRawYieldUnc) if i % 2 == 0]
+                listEffPrompt    = [x for i, x in enumerate(listEffPrompt) if i % 2 == 0]
+                listEffPromptUnc = [x for i, x in enumerate(listEffPromptUnc) if i % 2 == 0]
+                listEffFD        = [x for i, x in enumerate(listEffFD) if i % 2 == 0]
+                listEffFDUnc     = [x for i, x in enumerate(listEffFDUnc) if i % 2 == 0]
+            # Remove elements randomly if 'random' is in systematics
+            if 'random' in systematics:
+                random_bools = [gRandom.Uniform() > 0.5 for _ in range(len(listRawYield))]
+                listRawYield     = [x for x, b in zip(listRawYield, random_bools) if b]
+                listRawYieldUnc  = [x for x, b in zip(listRawYieldUnc, random_bools) if b]
+                listEffPrompt    = [x for x, b in zip(listEffPrompt, random_bools) if b]
+                listEffPromptUnc = [x for x, b in zip(listEffPromptUnc, random_bools) if b]
+                listEffFD        = [x for x, b in zip(listEffFD, random_bools) if b]
+                listEffFDUnc     = [x for x, b in zip(listEffFDUnc, random_bools) if b]
+
+        nSets = len(listRawYield)
         print(f'Pt: {ptMin:.1f}-{ptMax:.1f}')
         for i in range(len(listEffPrompt)):
-            print(f'Eff Prompt: {listEffPrompt[i]:.3f}    Eff FD: {listEffFD[i]:.3f}    Raw Yield: {listRawYield[i]:.2f}')
+            print(f'({i}) Eff Prompt: {listEffPrompt[i]:.6f}    Eff FD: {listEffFD[i]:.6f}    Raw Yield: {listRawYield[i]:.2f}')
 
         corrYields, covMatrixCorrYields, chiSquare, matrices = \
             GetPromptFDYieldsAnalyticMinimisation(listEffPrompt, listEffFD, listRawYield, listEffPromptUnc, listEffFDUnc,
@@ -159,8 +138,8 @@ def compute_frac_cut_var(config_flow, inputdir, outputdir, suffix, batch=False):
         hFDFracVsCut.append(TH1F(f'hFDFracVsCut_{ptString}', f'{commonString};#it{{f}}_{{FD}}', nSets, 0.5, nSets + 0.5))
 
         SetObjectStyle(hRawYieldsVsCut[iPt], linecolor=kBlack, markercolor=kBlack, markerstyle=kFullCircle)
-        SetObjectStyle(hRawYieldPromptVsCut[iPt], color=kRed+1, fillcolor=kRed+1, markerstyle=kOpenCircle, fillalpha=0.3)
-        SetObjectStyle(hRawYieldFDVsCut[iPt], color=kAzure+4, fillcolor=kAzure+4, markerstyle=kOpenSquare, fillalpha=0.3)
+        SetObjectStyle(hRawYieldPromptVsCut[iPt], color=kRed+1, fillcolor=kRed+1, markerstyle=kOpenCircle, fillalpha=0.3, fillstyle=3145)
+        SetObjectStyle(hRawYieldFDVsCut[iPt], color=kAzure+4, fillcolor=kAzure+4, markerstyle=kOpenSquare, fillalpha=0.3, fillstyle=3154)
         SetObjectStyle(hRawYieldsVsCutReSum[iPt], linecolor=kGreen+2)
         SetObjectStyle(hEffPromptVsCut[iPt], color=kRed+1, markerstyle=kFullCircle)
         SetObjectStyle(hEffFDVsCut[iPt], color=kAzure+4, markerstyle=kFullSquare)
@@ -215,6 +194,27 @@ def compute_frac_cut_var(config_flow, inputdir, outputdir, suffix, batch=False):
             hFDFracVsCut[iPt].SetBinError(iCutSet+1, fFDUnc)
 
         if iPt == 0:
+            legDistr = TLegend(0.45, 0.68, 0.75, 0.89)
+            legDistr.SetFillStyle(0)
+            legDistr.SetBorderSize(0)
+            legDistr.SetTextSize(0.045)
+
+            legEff = TLegend(0.2, 0.2, 0.4, 0.4)
+            legEff.SetFillStyle(0)
+            legEff.SetBorderSize(0)
+            legEff.SetTextSize(0.045)
+
+            legFrac = TLegend(0.2, 0.79, 0.4, 0.89)
+            legFrac.SetFillStyle(0)
+            legFrac.SetBorderSize(0)
+            legFrac.SetTextSize(0.045)
+
+            latInfo = TLatex()
+            latInfo.SetNDC()
+            latInfo.SetTextSize(0.045)
+            latInfo.SetTextFont(42)
+            latInfo.SetTextColor(1)
+
             legDistr.AddEntry(hRawYieldsVsCut[iPt], 'Measured raw yield', 'lpe')
             legDistr.AddEntry(hRawYieldPromptVsCut[iPt], 'Prompt', 'f')
             legDistr.AddEntry(hRawYieldFDVsCut[iPt], 'Non-prompt', 'f')
@@ -224,33 +224,33 @@ def compute_frac_cut_var(config_flow, inputdir, outputdir, suffix, batch=False):
             legFrac.AddEntry(hPromptFracVsCut[iPt], 'Prompt', 'lpe')
             legFrac.AddEntry(hFDFracVsCut[iPt], 'Non-prompt', 'lpe')
 
-        cEff.append(TCanvas(f'cEff_{ptString}', '', 800, 800))
-        cEff[iPt].DrawFrame(0.5, hEffPromptVsCut[iPt].GetMinimum()/5, nSets + 0.5, 1., f'{commonString};efficiency')
-        cEff[iPt].SetLogy()
-        hEffPromptVsCut[iPt].DrawCopy('same')
-        hEffFDVsCut[iPt].DrawCopy('same')
-        legEff.Draw()
-
-        cDistr.append(TCanvas(f'cDistr_{ptString}', '', 800, 800))
-        hFrameDistr = cDistr[iPt].DrawFrame(0.5, 0., nSets + 0.5, hRawYieldsVsCut[iPt].GetMaximum() * 1.2,
-                                            f'{commonString};raw yield')
+        cFinalResPt.append(TCanvas(f'cFinalRes_{ptString}', '', 800, 800))
+        cFinalResPt[-1].Divide(2, 2)
+        # top-left pad: correlation
+        cFinalResPt[-1].cd(1).SetRightMargin(0.14)
+        hCorrMatrixCutSets[iPt].Draw('colz text')
+        # top-right: template
+        hFrameDistr = cFinalResPt[-1].cd(2).DrawFrame(0.5, 0., nSets + 0.5, hRawYieldsVsCut[iPt].GetMaximum() * 1.2,
+                                    f'{commonString};raw yield')
         hFrameDistr.GetYaxis().SetDecimals()
         hRawYieldsVsCut[iPt].Draw('same')
         hRawYieldPromptVsCut[iPt].DrawCopy('histsame')
         hRawYieldFDVsCut[iPt].DrawCopy('histsame')
         hRawYieldsVsCutReSum[iPt].Draw('same')
         legDistr.Draw()
-        latInfo.DrawLatex(0.47, 0.65, f'#chi^{{2}} / ndf = {chiSquare:.3f}')
-
-        cFrac.append(TCanvas(f'cFrac_{ptString}', '', 800, 800))
-        cFrac[iPt].DrawFrame(0.5, 0., nSets + 0.5, 1.8, f'{commonString};fraction')
+        #latInfo.DrawLatex(0.47, 0.65, f'#chi^{{2}} / ndf = {chiSquare:.3f}') # DO NOT TRUST CHI2 IN RUN 3
+        # bottom-left: efficiency
+        cFinalResPt[-1].cd(3).DrawFrame(0.5, hEffPromptVsCut[iPt].GetMinimum()/5, nSets + 0.5, 1., f'{commonString};efficiency')
+        cFinalResPt[-1].cd(3).SetLogy()
+        hEffPromptVsCut[iPt].DrawCopy('same')
+        hEffFDVsCut[iPt].DrawCopy('same')
+        legEff.Draw()
+        # bottom-right: fraction
+        cFinalResPt[-1].cd(4).DrawFrame(0.5, 0., nSets + 0.5, 1.8, f'{commonString};fraction')
         hPromptFracVsCut[iPt].DrawCopy('Esame')
         hFDFracVsCut[iPt].DrawCopy('Esame')
         legFrac.Draw()
-
-        cCorrMatrix.append(TCanvas(f'cCorrMatrix_{ptString}', '', 800, 800))
-        cCorrMatrix[-1].cd().SetRightMargin(0.14)
-        hCorrMatrixCutSets[iPt].Draw('colz')
+        cFinalResPt[-1].Update()
 
     nPtBins = hCorrYieldPrompt.GetNbinsX()
     cCorrYield = TCanvas('cCorrYield', '', 800, 800)
@@ -274,9 +274,7 @@ def compute_frac_cut_var(config_flow, inputdir, outputdir, suffix, batch=False):
         outFile.mkdir(f"pt{ptmin:.1f}_{ptmax:.1f}")
         outFile.cd(f"pt{ptmin:.1f}_{ptmax:.1f}")
         print(f"Writing to dir pt{ptmin:.1f}_{ptmax:.1f} of file {outFile}")
-        cDistr[iPt].Write()
-        cEff[iPt].Write()
-        cFrac[iPt].Write()
+        cFinalResPt[iPt].Write()
         hRawYieldsVsCut[iPt].Write()
         hRawYieldPromptVsCut[iPt].Write()
         hRawYieldFDVsCut[iPt].Write()
@@ -288,27 +286,92 @@ def compute_frac_cut_var(config_flow, inputdir, outputdir, suffix, batch=False):
         hCorrMatrixCutSets[iPt].Write()
     outFile.Close()
 
-    outFileNameEffPDF = outFileName.replace('.root', '_Eff.pdf')
-    outFileNameDistrPDF = outFileName.replace('.root', '_Distr.pdf')
-    outFileNameFracPDF = outFileName.replace('.root', '_Frac.pdf')
-    outFileNameCorrMatrixPDF = outFileName.replace('.root', '_CorrMatrix.pdf')
     for iPt in range(len(ptmins)):
         if iPt == 0:
-            cEff[iPt].SaveAs(f'{outFileNameEffPDF}[')
-            cDistr[iPt].SaveAs(f'{outFileNameDistrPDF}[')
-            cFrac[iPt].SaveAs(f'{outFileNameFracPDF}[')
-            cCorrMatrix[iPt].SaveAs(f'{outFileNameCorrMatrixPDF}[')
-        cEff[iPt].SaveAs(outFileNameEffPDF)
-        cDistr[iPt].SaveAs(outFileNameDistrPDF)
-        cFrac[iPt].SaveAs(outFileNameFracPDF)
-        cCorrMatrix[iPt].SaveAs(outFileNameCorrMatrixPDF)
+            cFinalResPt[iPt].SaveAs(f'{outputdir}/CutVarFrac/FinalResPt_{suffix}.pdf[')
+        cFinalResPt[iPt].SaveAs(f'{outputdir}/CutVarFrac/FinalResPt_{suffix}.pdf')
         if iPt == hRawYields[0].GetNbinsX() - 1:
-            cEff[iPt].SaveAs(f'{outFileNameEffPDF}]')
-            cDistr[iPt].SaveAs(f'{outFileNameDistrPDF}]')
-            cFrac[iPt].SaveAs(f'{outFileNameFracPDF}]')
-            cCorrMatrix[iPt].SaveAs(f'{outFileNameCorrMatrixPDF}]')
+            cFinalResPt[iPt].SaveAs(f'{outputdir}/CutVarFrac/FinalResPt_{suffix}.pdf]')
+        cFinalResPt[iPt].SaveAs(f'{outputdir}/CutVarFrac/FinalResPt_{suffix}_pt{ptmins[iPt]}_{ptmaxs[iPt]}.png')
     
+
+def compute_frac_cut_var(config_flow, inputdir, outputdir, suffix, batch=False):
+
+    gROOT.SetBatch(batch)
+    gStyle.SetPaintTextFormat("4.2f")
+
+    CutSets, _, _, _, _ = get_cut_sets_config(config_flow)
+    with open(config_flow, 'r') as ymlCfgFile:
+        config = yaml.load(ymlCfgFile, yaml.FullLoader)
+
+    if os.path.exists(f'{inputdir}/eff'):
+        effFiles = [f'{inputdir}/eff/{file}'
+                    for file in os.listdir(f'{inputdir}/eff') if file.endswith('.root') and suffix in file]
+    else:
+        raise ValueError(f'No eff fodel found in {inputdir}')
     
+    if os.path.exists(f'{inputdir}/ry'):
+        rawYieldFiles = [f'{inputdir}/ry/{file}' 
+                        for file in os.listdir(f'{inputdir}/ry') if file.endswith('.root') and suffix in file]
+    else:
+        raise ValueError(f'No ry folder found in {inputdir}')
+    
+    effFiles.sort()
+    rawYieldFiles.sort()
+
+    # load configuration
+    ptmins = config['ptmins']
+    ptmaxs = config['ptmaxs']
+
+    hRawYields, hEffPrompt, hEffFD = [], [], []
+
+    # load inputs raw yields and efficiencies
+    for inFileNameRawYield, inFileNameEff in zip(rawYieldFiles, effFiles):
+
+        #input(f'Opening file: {inFileNameRawYield} and {inFileNameEff}')
+        inFileRawYield = ROOT.TFile.Open(inFileNameRawYield)
+        # if hRawYieldsSimFit not in file, skip it
+        if not inFileRawYield.GetListOfKeys().Contains('hRawYieldsSimFit'):
+            print(f'File {inFileNameRawYield} does not contain hRawYieldsSimFit. Skipping.')
+            continue
+        hRawYields.append(inFileRawYield.Get('hRawYieldsSimFit'))
+        hRawYields[-1].SetDirectory(0)
+        
+        inFileEff = TFile.Open(inFileNameEff)
+        hEffPrompt.append(inFileEff.Get('hEffPrompt'))
+        hEffFD.append(inFileEff.Get('hEffFD'))
+        hEffPrompt[-1].SetDirectory(0)
+        hEffFD[-1].SetDirectory(0)
+
+    SetGlobalStyle(padleftmargin=0.15, padtopmargin=0.08, titleoffsetx=1.,
+                titleoffsety=1.4, opttitle=1, palette=kRainBow, maxdigits=2)
+
+    legDistr = TLegend(0.45, 0.68, 0.75, 0.89)
+    legDistr.SetFillStyle(0)
+    legDistr.SetBorderSize(0)
+    legDistr.SetTextSize(0.045)
+
+    legEff = TLegend(0.2, 0.2, 0.4, 0.4)
+    legEff.SetFillStyle(0)
+    legEff.SetBorderSize(0)
+    legEff.SetTextSize(0.045)
+
+    legFrac = TLegend(0.2, 0.79, 0.4, 0.89)
+    legFrac.SetFillStyle(0)
+    legFrac.SetBorderSize(0)
+    legFrac.SetTextSize(0.045)
+
+    latInfo = TLatex()
+    latInfo.SetNDC()
+    latInfo.SetTextSize(0.045)
+    latInfo.SetTextFont(42)
+    latInfo.SetTextColor(1)
+
+    minimise_chi2(config, ptmins, ptmaxs, hRawYields, hEffPrompt, hEffFD, outputdir, suffix, False)
+    for syst in config['minimisation']['systematics']:
+        print(f'Running systematics: {syst}')
+        minimise_chi2(config, ptmins, ptmaxs, hRawYields, hEffPrompt, hEffFD, f'{outputdir}/Syst', syst, systematics=syst)
+
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='Arguments')
@@ -324,4 +387,4 @@ if __name__ == "__main__":
                         help="run in batch mode")
     args = parser.parse_args()
 
-    compute_frac_cut_var(args.config, args.inputdir, args.outputdir, args.suffix, args.batch)
+    compute_frac_cut_var(args.config_flow, args.inputdir, args.outputdir, args.suffix, args.batch)

--- a/run3/flow/BDT/compute_frac_cut_var.py
+++ b/run3/flow/BDT/compute_frac_cut_var.py
@@ -66,20 +66,22 @@ def minimise_chi2(config, ptmins, ptmaxs, hRawYields, hEffPrompt, hEffFD, output
             listEffFDUnc.append(hEffF.GetBinError(iPt+1))
 
         if systematics:
+            # Remove the loosest 3 cuts if 'minus3low' or 'minus' is in systematics
             if systematics == 'minus3low' or systematics == 'minus3':
-                listRawYield     = [x for i, x in enumerate(listRawYield) if i < 3]
-                listRawYieldUnc  = [x for i, x in enumerate(listRawYieldUnc) if i < 3]
-                listEffPrompt    = [x for i, x in enumerate(listEffPrompt) if i < 3]
-                listEffPromptUnc = [x for i, x in enumerate(listEffPromptUnc) if i < 3]
-                listEffFD        = [x for i, x in enumerate(listEffFD) if i < 3]
-                listEffFDUnc     = [x for i, x in enumerate(listEffFDUnc) if i < 3]
+                listRawYield     = listRawYield[2:]
+                listRawYieldUnc  = listRawYieldUnc[2:]
+                listEffPrompt    = listEffPrompt[2:]
+                listEffPromptUnc = listEffPromptUnc[2:]
+                listEffFD        = listEffFD[2:]
+                listEffFDUnc     = listEffFDUnc[2:]
+            # Remove the tightest 3 cuts if 'minus3high' or 'minus' is in systematics
             if systematics == 'minus3high' or systematics == 'minus3':
-                listRawYield     = [x for i, x in enumerate(listRawYield) if i > len(listRawYield) - 3]
-                listRawYieldUnc  = [x for i, x in enumerate(listRawYieldUnc) if i > len(listRawYield) - 3]
-                listEffPrompt    = [x for i, x in enumerate(listEffPrompt) if i > len(listRawYield) - 3]
-                listEffPromptUnc = [x for i, x in enumerate(listEffPromptUnc) if i > len(listRawYield) - 3]
-                listEffFD        = [x for i, x in enumerate(listEffFD) if i > len(listRawYield) - 3]
-                listEffFDUnc     = [x for i, x in enumerate(listEffFDUnc) if i > len(listRawYield) - 3]
+                listRawYield     = listRawYield[:-3]
+                listRawYieldUnc  = listRawYieldUnc[:-3]
+                listEffPrompt    = listEffPrompt[:-3]
+                listEffPromptUnc = listEffPromptUnc[:-3]
+                listEffFD        = listEffFD[:-3]
+                listEffFDUnc     = listEffFDUnc[:-3]
             # Remove even-indexed elements if 'even' is in systematics
             if 'even' in systematics:
                 listRawYield     = [x for i, x in enumerate(listRawYield) if i % 2 != 0]
@@ -105,6 +107,22 @@ def minimise_chi2(config, ptmins, ptmaxs, hRawYields, hEffPrompt, hEffFD, output
                 listEffPromptUnc = [x for x, b in zip(listEffPromptUnc, random_bools) if b]
                 listEffFD        = [x for x, b in zip(listEffFD, random_bools) if b]
                 listEffFDUnc     = [x for x, b in zip(listEffFDUnc, random_bools) if b]
+            # Remove 1 element every 3 '1in3' is in systematics
+            if '1in3' in systematics:
+                listRawYield     = [x for i, x in enumerate(listRawYield) if i % 3 == 0]
+                listRawYieldUnc  = [x for i, x in enumerate(listRawYieldUnc) if i % 3 == 0]
+                listEffPrompt    = [x for i, x in enumerate(listEffPrompt) if i % 3 == 0]
+                listEffPromptUnc = [x for i, x in enumerate(listEffPromptUnc) if i % 3 == 0]
+                listEffFD        = [x for i, x in enumerate(listEffFD) if i % 3 == 0]
+                listEffFDUnc     = [x for i, x in enumerate(listEffFDUnc) if i % 3 == 0]
+            # Remove 1 element every 4 '1in4' is in systematics
+            if '1in4' in systematics:
+                listRawYield     = [x for i, x in enumerate(listRawYield) if i % 4 == 0]
+                listRawYieldUnc  = [x for i, x in enumerate(listRawYieldUnc) if i % 4 == 0]
+                listEffPrompt    = [x for i, x in enumerate(listEffPrompt) if i % 4 == 0]
+                listEffPromptUnc = [x for i, x in enumerate(listEffPromptUnc) if i % 4 == 0]
+                listEffFD        = [x for i, x in enumerate(listEffFD) if i % 4 == 0]
+                listEffFDUnc     = [x for i, x in enumerate(listEffFDUnc) if i % 4 == 0]
 
         nSets = len(listRawYield)
         print(f'Pt: {ptMin:.1f}-{ptMax:.1f}')
@@ -262,8 +280,12 @@ def minimise_chi2(config, ptmins, ptmaxs, hRawYields, hEffPrompt, hEffFD, output
     hCorrYieldFD.Draw('same')
     legEff.Draw()
 
-    os.makedirs(f'{outputdir}/CutVarFrac', exist_ok=True)
-    outFileName = f'{outputdir}/CutVarFrac/CutVarFrac_{suffix}.root'
+    if systematics:
+        directory = f'{systematics}/CutVarFrac'
+    else:
+        directory = 'CutVarFrac'
+    os.makedirs(f'{outputdir}/{directory}', exist_ok=True)
+    outFileName = f'{outputdir}/{directory}/CutVarFrac_{suffix}.root'
     outFile = TFile(outFileName, 'recreate')
     cCorrYield.Write()
     hCorrYieldPrompt.Write()
@@ -288,11 +310,11 @@ def minimise_chi2(config, ptmins, ptmaxs, hRawYields, hEffPrompt, hEffFD, output
 
     for iPt in range(len(ptmins)):
         if iPt == 0:
-            cFinalResPt[iPt].SaveAs(f'{outputdir}/CutVarFrac/FinalResPt_{suffix}.pdf[')
-        cFinalResPt[iPt].SaveAs(f'{outputdir}/CutVarFrac/FinalResPt_{suffix}.pdf')
+            cFinalResPt[iPt].SaveAs(f'{outputdir}/{directory}/FinalResPt_{suffix}.pdf[')
+        cFinalResPt[iPt].SaveAs(f'{outputdir}/{directory}/FinalResPt_{suffix}.pdf')
         if iPt == hRawYields[0].GetNbinsX() - 1:
-            cFinalResPt[iPt].SaveAs(f'{outputdir}/CutVarFrac/FinalResPt_{suffix}.pdf]')
-        cFinalResPt[iPt].SaveAs(f'{outputdir}/CutVarFrac/FinalResPt_{suffix}_pt{ptmins[iPt]}_{ptmaxs[iPt]}.png')
+            cFinalResPt[iPt].SaveAs(f'{outputdir}/{directory}/FinalResPt_{suffix}.pdf]')
+        cFinalResPt[iPt].SaveAs(f'{outputdir}/{directory}/FinalResPt_{suffix}_pt{ptmins[iPt]}_{ptmaxs[iPt]}.png')
     
 
 def compute_frac_cut_var(config_flow, inputdir, outputdir, suffix, batch=False):
@@ -368,9 +390,10 @@ def compute_frac_cut_var(config_flow, inputdir, outputdir, suffix, batch=False):
     latInfo.SetTextColor(1)
 
     minimise_chi2(config, ptmins, ptmaxs, hRawYields, hEffPrompt, hEffFD, outputdir, suffix, False)
-    for syst in config['minimisation']['systematics']:
-        print(f'Running systematics: {syst}')
-        minimise_chi2(config, ptmins, ptmaxs, hRawYields, hEffPrompt, hEffFD, f'{outputdir}/Syst', syst, systematics=syst)
+    if 'systematics' in config['minimisation']:
+        for syst in config['minimisation']['systematics']:
+            print(f'Running systematics: {syst}')
+            minimise_chi2(config, ptmins, ptmaxs, hRawYields, hEffPrompt, hEffFD, f'{outputdir}/Syst', syst, systematics=syst)
 
 
 if __name__ == "__main__":

--- a/run3/flow/BDT/compute_syst_fFD.py
+++ b/run3/flow/BDT/compute_syst_fFD.py
@@ -1,0 +1,174 @@
+import sys
+import os
+import numpy as np
+import argparse
+import yaml
+from ROOT import TFile, TCanvas, kFullSquare, kBlack, kOrange, kAzure, kGray, kRed, TLegend, kCyan, kSpring, kGreen, kBlue, kMagenta, kFullCircle, TGraphErrors, TH1F
+sys.path.append('../../../')
+from utils.StyleFormatter import SetGlobalStyle, SetObjectStyle
+
+SetGlobalStyle(titleoffsety=1.4, maxdigits=3, topmargin=0.1, bottommargin=0.4, leftmargin=1, rightmargin=0.15,
+               labelsizey=0.04, setoptstat=0, setopttitle=0, setdecimals=True,titleoffsetx=0.94)
+cols = [kBlack, kOrange+1, kAzure+4, kRed+1, kCyan+2, kGreen+2, kBlue-4, kMagenta+2, kSpring+2]
+labels = ['default', 'random', 'even', 'odd', 'step1', 'step2', 'minus3low', 'minus3high', 'minus3']
+
+def get_hdeltav(href, hsyst):
+    hdelta = hsyst.Clone()
+    hdelta.Reset()
+    hdelta.SetDirectory(0)
+    for ibin in range(1, href.GetNbinsX()+1):
+        hdelta.SetBinContent(ibin, hsyst.GetBinContent(ibin)-href.GetBinContent(ibin))
+        hdelta.SetBinError(ibin, 1.e-9)
+
+    return hdelta
+
+def get_rms_shift(histsdeltav2):
+    gsyst = TGraphErrors(-1)
+    SetObjectStyle(gsyst, color=kAzure+2, fillcolor=kAzure+2, linewidth=0, fillalpha=0.2, linestyle=8, fillstyle=3154)
+    for ibin in range(1, histsdeltav2[0].GetNbinsX()+1):
+        hsyst = TH1F('', '', 20000, -0.1, 0.1)
+        for hist in histsdeltav2[1:]: # skipping default
+            hsyst.Fill(hist.GetBinContent(ibin))
+        #hsyst.Draw()
+        gsyst.SetPoint(ibin, histsdeltav2[0].GetBinCenter(ibin), 0)
+        gsyst.SetPointError(ibin, histsdeltav2[0].GetBinWidth(ibin)/2, np.sqrt(hsyst.GetRMS()**2 + hsyst.GetMean()**2))
+        #print(f'(pT cent: {histsdeltav2[0].GetBinCenter(ibin)}) Syst = {np.sqrt(hsyst.GetRMS()**2 + hsyst.GetMean()**2)}, rms = {hsyst.GetRMS()}, mu = {hsyst.GetMean()}')
+
+    return gsyst
+
+
+def compute_syst(infiles, outputdir, suffix):
+    #______________________________________________________________________________________
+    # Collect all .root files
+    hv2_prompt = []
+    hv2_fd = []
+    hdeltav2_prompt = []
+    hdeltav2_fd = []
+    gv2vsfrac = {}
+    for ifile, file in enumerate(infiles):
+        print(f'INFO: Found {file}')
+        tfile = TFile().Open(file)
+        # check if the file has the right keys
+        if not tfile.GetListOfKeys().Contains('hV2VsPtFD') or not tfile.GetListOfKeys().Contains('hV2VsPtPrompt'):
+            print(f'ERROR: {file} does not contain hV2VsPtFD or hV2VsPtPrompt')
+            continue
+        hv2_prompt.append(tfile.Get('hV2VsPtPrompt'))
+        hv2_fd.append(tfile.Get('hV2VsPtFD'))
+
+        gv2vsfrac[labels[ifile]] = []
+        for ibin in range(1, hv2_prompt[0].GetNbinsX()+1):
+            ptmin = hv2_prompt[0].GetXaxis().GetBinLowEdge(ibin)
+            ptmax = hv2_prompt[0].GetXaxis().GetBinLowEdge(ibin) + hv2_prompt[0].GetXaxis().GetBinWidth(ibin)
+            print(f'pt_{ptmin*10:.0f}_{ptmax*10:.0f}/cFrac_{ptmin:.0f}_{ptmax:.0f}')
+            gv2vsfrac[labels[ifile]].append(tfile.Get(f'pt_{ptmin*10:.0f}_{ptmax*10:.0f}/gV2VsFrac'))
+            SetObjectStyle(gv2vsfrac[labels[ifile]][-1], color=cols[ifile], fillcolor=cols[ifile], markerstyle=kFullCircle, markersize=2, linewidth=2, fillalpha=0.2)
+
+        hv2_prompt[-1].SetDirectory(0)
+        hv2_fd[-1].SetDirectory(0)
+        SetObjectStyle(hv2_prompt[-1], color=cols[ifile], fillcolor=cols[ifile], markerstyle=kFullCircle, markersize=2, linewidth=2, fillalpha=0.2)
+        SetObjectStyle(hv2_fd[-1], color=cols[ifile], fillcolor=cols[ifile], markerstyle=kFullSquare, markersize=2, linewidth=2, fillalpha=0.2)
+
+        hdeltav2_prompt.append(get_hdeltav(hv2_prompt[0], hv2_prompt[ifile]))
+        hdeltav2_fd.append(get_hdeltav(hv2_fd[0], hv2_fd[ifile]))
+    gsyst_prompt = get_rms_shift(hdeltav2_prompt)
+    gsyst_fd = get_rms_shift(hdeltav2_fd)
+
+    canv_fFD = TCanvas('canv', 'canv', 1600, 1600)
+    canv_fFD.Divide(4, 4)
+    for igs, gfracs in enumerate(gv2vsfrac):
+        print(gfracs)
+        for ig, gfrac in enumerate(gv2vsfrac[gfracs]):
+            canv_fFD.cd(ig+1)
+            if igs == 0:
+                gfrac.Draw('pea')
+            else:
+                gfrac.Draw('same pe')
+    canv_fFD.Update()
+
+    #______________________________________________________________________________________
+    # Plot the systematics
+    canv = TCanvas('canv', 'canv', 1600, 1600)
+    canv.Divide(2, 2)
+    
+    legv2 = TLegend(0.6, 0.6, 0.9, 0.9)
+    legv2.SetBorderSize(0)
+    legv2.SetFillStyle(0)
+    legv2.SetTextSize(0.03)
+    legv2.SetTextFont(42)
+    
+    legsyst = TLegend(0.6, 0.79, 0.9, 0.89)
+    legsyst.SetBorderSize(0)
+    legsyst.SetFillStyle(0)
+    legsyst.SetTextSize(0.03)
+    legsyst.SetTextFont(42)
+    
+    canv.cd(1).SetLeftMargin(0.16)
+    canv.cd(1)
+    for ihist, hist in enumerate(hv2_prompt):
+        hist.SetStats(0)
+        hist.GetXaxis().SetTitle('#it{p}_{T} (GeV/#it{c})')
+        hist.GetYaxis().SetTitle('prompt #it{v}_{2}')
+        hist.GetXaxis().SetRangeUser(0, 25)
+        hist.GetYaxis().SetRangeUser(-0.1, 0.35)
+        legv2.AddEntry(hist, labels[ihist], 'lp')
+        hist.Draw('same')
+    legv2.Draw()
+    canv.cd(2).SetLeftMargin(0.16)
+    for _, hist in enumerate(hv2_fd):
+        hist.SetStats(0)
+        hist.GetXaxis().SetTitle('#it{p}_{T} (GeV/#it{c})')
+        hist.GetYaxis().SetTitle('non-prompt #it{v}_{2}')
+        hist.GetXaxis().SetRangeUser(0, 25)
+        hist.GetYaxis().SetRangeUser(-0.2, 0.35)
+        hist.Draw('same')
+    canv.cd(3).SetGridy()
+    canv.cd(3).SetLeftMargin(0.16)
+    for _, hist in enumerate(hdeltav2_prompt):
+        hist.SetStats(0)
+        hist.GetXaxis().SetTitle('#it{p}_{T} (GeV/#it{c})')
+        hist.GetYaxis().SetTitle('prompt #it{v}_{2}^{syst.} #minus #it{v}_{2}^{ref.}')
+        hist.GetXaxis().SetRangeUser(0, 25)
+        hist.GetYaxis().SetRangeUser(-0.05, 0.05)
+        hist.Draw('samepe')
+    gsyst_prompt.Draw('same5')
+    legsyst.AddEntry(gsyst_prompt, f'#sqrt{{shift^{{2}} + rms^{{2}}}}', 'f')
+    legsyst.Draw()
+    canv.cd(4).SetGridy()
+    canv.cd(4).SetLeftMargin(0.16)
+    for _, hist in enumerate(hdeltav2_fd):
+        hist.SetStats(0)
+        hist.GetXaxis().SetTitle('#it{p}_{T} (GeV/#it{c})')
+        hist.GetYaxis().SetTitle('non-prompt #it{v}_{2}^{syst.} #minus #it{v}_{2}^{ref.}')
+        hist.GetXaxis().SetRangeUser(0, 25)
+        hist.GetYaxis().SetRangeUser(-0.05, 0.05)
+        hist.Draw('samepe')
+    gsyst_fd.Draw('same5')
+
+    canv.Update()
+    input('Press enter to exit.')
+
+    #______________________________________________________________________________________
+    # Save output
+    outputfile = os.path.join(outputdir, f'syst_fFD_{suffix}.root')
+    outfile = TFile(outputfile, 'RECREATE')
+    canv.Write()
+    outfile.Close()
+    print(f'INFO: Output saved in {outputfile}')
+
+    canv.SaveAs(f'{outputdir}/SystfFD_{suffix}.pdf')
+    canv.SaveAs(f'{outputdir}/SystfFD_{suffix}.png')
+
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description='Arguments')
+    parser.add_argument('infiles', metavar='text', nargs='*', default='path/to/syst/files')
+    parser.add_argument("--suffix", "-s", metavar="text",
+                        default="", help="suffix for output files")
+    parser.add_argument("--outputdir", "-o", metavar="text",
+                        default=".", help="output directory")
+    args = parser.parse_args()
+
+    compute_syst(args.infiles,
+                 args.outputdir,
+                 args.suffix)

--- a/run3/flow/BDT/fFD_syst.sh
+++ b/run3/flow/BDT/fFD_syst.sh
@@ -1,0 +1,126 @@
+#!/bin/bash
+# Bash script to compute resolution systematics in flow analysis
+
+########################################
+# Define paths and configuration
+########################################
+
+# Default cut variation path (uncorrected)
+export cutvar_default="path/to/default/V2VsFrac"
+
+# Array of systematic variation paths (e.g., for "random" and "even" variations)
+cutvar_systvariation_paths=(
+  "path/to/Syst/random"
+  "path/to/Syst/even"
+  "path/to/Syst/odd"
+  "path/to/Syst/1in4"
+  "path/to/Syst/1in3"
+  "path/to/Syst/minus3low"
+  "path/to/Syst/minus3high"
+  "path/to/Syst/minus3"
+)
+
+# Other important paths
+export corrPath="path/to/correlated/folder"
+export uncorrPath="path/to/uncorr/fodler/"
+export output_dir="output/dir"  # Output directory for results
+export config="../config_flow.yml"
+export n_parallel=2  # Number of parallel jobs
+
+########################################
+# Parallel function to run analysis for each configuration
+########################################
+
+parallel_func() {
+    local corrPath="$1"
+
+    # Check if the efficiency folder already exists in corrPath.
+    # If not, copy it from the uncorrected path.
+    if [ -d "$corrPath/eff" ]; then
+        echo "Efficiency folder already exists in $corrPath"
+    else
+        echo "Copying the efficiency files from $uncorrPath/eff to $corrPath/eff"
+        cp -r "$uncorrPath/eff" "$corrPath/eff"
+    fi
+    
+    # Compute a suffix from corrPath:
+    # Example: If corrPath is "CutVarFrac_XXX.root", suffix becomes "CutVarFrac".
+    local base
+    base=$(basename "$corrPath")
+    local suffix="${base%%_*}"   # Extract text before the first underscore
+
+    # Determine the parent directory of corrPath's parent directory.
+    # This could be used as the "cut variation" directory.
+    local path_to_cutvar
+    path_to_cutvar="$(dirname "$(dirname "$corrPath")")"
+    echo "Path to cutvar: $path_to_cutvar"
+    echo "Suffix: $suffix"
+
+    ########################################
+    # Build and execute Python commands
+    ########################################
+
+    # (Optional) Command to compute data-driven fractions (currently commented out)
+    local cmd=(python3 "./ComputeDataDriFrac_flow.py" -i "$corrPath" -o "$corrPath" -s "$suffix" -b -comb -cc "$corrPath" -oc "$corrPath")
+    echo "Executing: ${cmd[*]}"
+    "${cmd[@]}"
+
+    # Command to compute prompt FD v2
+    local cmd=(python3 "./ComputeV2vsFDFrac.py" "$config" -i "$uncorrPath" -o "$corrPath" -s "$suffix" -comb -ic "$corrPath" -oc "$corrPath")
+    echo "Executing: ${cmd[*]}"
+    "${cmd[@]}"
+}
+export -f parallel_func
+
+########################################
+# Run the analysis for each configuration in parallel
+########################################
+
+# Change directory to the BDT folder (adjust as necessary)
+cd ../BDT/ || { echo "Failed to change directory to ../BDT/"; exit 1; }
+
+echo "Running parallel jobs with n_parallel: $n_parallel"
+
+# Use GNU Parallel to run the function for each systematic variation path in the array
+parallel -j "$n_parallel" parallel_func ::: "${cutvar_systvariation_paths[@]}"
+
+########################################
+# Further commands for computing systematic uncertainties can be added below
+########################################
+# Change directory to the BDT folder (adjust as necessary)
+cd ../systematics/ || { echo "Failed to change directory to ../systematics/"; exit 1; }
+
+echo "Computing systeamtic"
+# Enable recursive globbing so that ** searches through all subdirectories
+shopt -s globstar
+
+# Declare an array to store all file paths
+all_v2_files=()
+
+# Add reference to cutvar_systvariation_paths
+cutvar_systvariation_paths=(
+  "$cutvar_default"
+  "${cutvar_systvariation_paths[@]}"
+)
+# Iterate over each systematic variation path
+for syst_path in "${cutvar_systvariation_paths[@]}"; do
+    echo "Searching in: $syst_path"
+    
+    # Find all files matching the pattern V2VsFrac*.root in any subfolder
+    mapfile -t files < <(find "$syst_path" -type f -name "V2VsFrac*.root")
+
+    # Check if any files were found
+    if [ ${#files[@]} -eq 0 ]; then
+        echo "No V2VsFrac*.root files found in $syst_path"
+    else
+        # Append found files to the global list
+        echo "V2VsFrac.root file found in $syst_path"
+        all_v2_files+=("${files[@]}")
+    fi
+done
+
+# Disable recursive globbing if no longer needed
+shopt -u globstar
+
+echo "Running python3 compute_syst_fFD.py -s $cutvar_systvariation_paths -o $output_dir"
+python3 compute_syst_fFD.py ${all_v2_files[@]} -s $cutvar_systvariation_paths -o $output_dir

--- a/run3/flow/BDT/proj_thn.py
+++ b/run3/flow/BDT/proj_thn.py
@@ -380,7 +380,6 @@ if __name__ == "__main__":
     cent, (cent_min, cent_max) = get_centrality_bins(args.centrality)
     outfile_dir = 'hf-candidate-creator-2prong' if config['Dmeson'] == 'Dzero' else 'hf-candidate-creator-3prong'
     # REVIEW the mc_filename is the same as the eff_filename so no need to use mc_filename.
-    print('infilemc')
     infilemc = TFile.Open(config['eff_filename'], 'r')
     histo_cent = infilemc.Get(f'{outfile_dir}/hSelCollisionsCent')
     histo_cent.GetXaxis().SetRangeUser(cent_min, cent_max)
@@ -406,12 +405,10 @@ if __name__ == "__main__":
     histo_cent.Write()
     resofile.Close()
     infilemc.Close()
-    print('infilemc.Close()')
-
+    
     # load thnsparse
     # REVIEW: 
     # for the main workflow, only the config_flow
-    print('LOADING')
     sparsesFlow, sparsesReco, sparsesGen, axes = get_sparses(config, True, True, True, args.anres_dir, args.preprocessed, f'{config["skim_out_dir"]}')
     if not args.preprocessed:
         for key, iSparse in sparsesFlow.items():

--- a/run3/flow/BDT/proj_thn.py
+++ b/run3/flow/BDT/proj_thn.py
@@ -405,11 +405,11 @@ if __name__ == "__main__":
     histo_cent.Write()
     resofile.Close()
     infilemc.Close()
-    
+
     # load thnsparse
     # REVIEW: 
     # for the main workflow, only the config_flow
-    sparsesFlow, sparsesReco, sparsesGen, axes = get_sparses(config, True, True, True, args.anres_dir, args.preprocessed, f'{config["skim_out_dir"]}')
+    sparsesFlow, sparsesReco, sparsesGen, axes = get_sparses(config, True, True, True, args.anres_dir, args.preprocessed, f'{config.get("skim_out_dir", "")}')
     if not args.preprocessed:
         for key, iSparse in sparsesFlow.items():
             iSparse.GetAxis(axes['Flow']['cent']).SetRangeUser(cent_min, cent_max)

--- a/run3/flow/BDT/proj_thn.py
+++ b/run3/flow/BDT/proj_thn.py
@@ -50,6 +50,7 @@ def proj_data(sparse_flow, ptMin, ptMax, cent_min, cent_max, axes, inv_mass_bins
             hist_vn_sp.Scale(1./reso)
     else:
         hist_mass = sparse_flow.Projection(axes['Flow']['Mass'])
+        hist_fd = sparse_flow.Projection(axes['Flow']['score_FD'])
         hist_vn_sp = get_vn_versus_mass(sparse_flow, inv_mass_bins, axes['Flow']['Mass'], axes['Flow']['sp'])
         hist_vn_sp.SetDirectory(0)
         if reso > 0:
@@ -353,7 +354,7 @@ if __name__ == "__main__":
     parser.add_argument('cutsetConfig', metavar='text',
                         default='cutsetConfig.yaml', help='cutset configuration file')
     parser.add_argument('anres_dir', metavar='text', 
-                        nargs='+', help='input ROOT files with anres')
+                        nargs='*', help='input ROOT files with anres')
     parser.add_argument('--preprocessed', action='store_true', 
                         help='Determines whether the sparses are pre-processed')
     parser.add_argument("--ptweights", "-w", metavar="text", nargs=2, required=False,
@@ -379,6 +380,7 @@ if __name__ == "__main__":
     cent, (cent_min, cent_max) = get_centrality_bins(args.centrality)
     outfile_dir = 'hf-candidate-creator-2prong' if config['Dmeson'] == 'Dzero' else 'hf-candidate-creator-3prong'
     # REVIEW the mc_filename is the same as the eff_filename so no need to use mc_filename.
+    print('infilemc')
     infilemc = TFile.Open(config['eff_filename'], 'r')
     histo_cent = infilemc.Get(f'{outfile_dir}/hSelCollisionsCent')
     histo_cent.GetXaxis().SetRangeUser(cent_min, cent_max)
@@ -404,10 +406,12 @@ if __name__ == "__main__":
     histo_cent.Write()
     resofile.Close()
     infilemc.Close()
+    print('infilemc.Close()')
 
     # load thnsparse
     # REVIEW: 
     # for the main workflow, only the config_flow
+    print('LOADING')
     sparsesFlow, sparsesReco, sparsesGen, axes = get_sparses(config, True, True, True, args.anres_dir, args.preprocessed, f'{config["skim_out_dir"]}')
     if not args.preprocessed:
         for key, iSparse in sparsesFlow.items():

--- a/run3/flow/BDT/run_cutvar.py
+++ b/run3/flow/BDT/run_cutvar.py
@@ -14,292 +14,288 @@ from concurrent.futures import ProcessPoolExecutor
 
 def check_dir(dir):
 
-	if not os.path.exists(dir):
-		print(f"\033[32m{dir} does not exist, it will be created\033[0m")
-		os.makedirs(dir)
-	else:
-		print(f"\033[33m{dir} already exists, it will be removed and recreated\033[0m")
-		shutil.rmtree(dir)
-		os.makedirs(dir)
+    if not os.path.exists(dir):
+        print(f"\033[32m{dir} does not exist, it will be created\033[0m")
+        os.makedirs(dir)
+    else:
+        print(f"\033[33m{dir} already exists, it will be removed and recreated\033[0m")
+        shutil.rmtree(dir)
+        os.makedirs(dir)
 
-	return
+    return
 
 def run_full_cut_variation(config_flow,
                            use_preprocessed, 
-						   calc_weights=False,
-						   make_yaml=False, 
-						   proj=False,
-						   efficiency=False,
-						   vn = False,
-						   frac_cut_var=False,
-						   data_driven_frac=False,
-						   v2_vs_frac=False,
-         				   merge_images=False):    
+                           calc_weights=False,
+                           make_yaml=False, 
+                           proj=False,
+                           efficiency=False,
+                           vn = False,
+                           frac_cut_var=False,
+                           data_driven_frac=False,
+                           v2_vs_frac=False,
+                            merge_images=False):    
 #___________________________________________________________________________________________________________________________
-	# Load and copy the configuration file
-	with open(config_flow, 'r') as cfgFlow:
-		config = yaml.safe_load(cfgFlow)
+    # Load and copy the configuration file
+    with open(config_flow, 'r') as cfgFlow:
+        config = yaml.safe_load(cfgFlow)
 
-	anres_dir = config['anresdir'] 
-	cent = config['centrality'] 
-	res_file = config['res_file'] 
-	output = config['out_dir'] 
-	suffix = config['suffix'] 
-	vn_method = config['vn_method']
-	n_workers = config['nworkers']
-	
-	CutSets, _, _, _, _ = get_cut_sets_config(config_flow)
-	# REVIEW: uniformize the max cutsets variable
-	mCutSets = max(CutSets)
+    anres_dir = config['anresdir'] 
+    cent = config['centrality'] 
+    res_file = config['res_file'] 
+    output = config['out_dir'] 
+    suffix = config['suffix'] 
+    vn_method = config['vn_method']
+    n_workers = config['nworkers']
 
-	print(f"\033[32mINFO: Number of cutsets: {mCutSets}\033[0m")
+    CutSets, _, _, _, _ = get_cut_sets_config(config_flow)
+    # REVIEW: uniformize the max cutsets variable
+    mCutSets = max(CutSets)
 
-	output_dir = f"{output}/cutvar_{suffix}"
+    print(f"\033[32mINFO: Number of cutsets: {mCutSets}\033[0m")
+
+    output_dir = f"{output}/cutvar_{suffix}"
  
-	os.system(f"mkdir -p {output_dir}")
+    os.system(f"mkdir -p {output_dir}")
   
-	# copy the configuration file
-	config_suffix = 0
-	os.makedirs(f'{output_dir}/config_flow', exist_ok=True)
-	while os.path.exists(f'{output_dir}/config_flow/config_flow_{suffix}_{config_suffix}.yml'):
-		config_suffix = config_suffix + 1
-	os.system(f'cp {config_flow} {output_dir}/{os.path.splitext(os.path.basename(config_flow))[0]}_{suffix}_{config_suffix}.yml')
+    # copy the configuration file
+    config_suffix = 0
+    os.makedirs(f'{output_dir}/config_flow', exist_ok=True)
+    while os.path.exists(f'{output_dir}/config_flow/config_flow_{suffix}_{config_suffix}.yml'):
+        config_suffix = config_suffix + 1
+    os.system(f'cp {config_flow} {output_dir}/{os.path.splitext(os.path.basename(config_flow))[0]}_{suffix}_{config_suffix}.yml')
 
-	# backup the results into history
-	file_to_check = f"{output_dir}/V2VsFrac/V2VsFrac_{suffix}.root"
-	if os.path.exists(file_to_check):
-		for sub_path in ['ry', 'CutVarFrac', 'V2VsFrac']:
-			os.system(f"mkdir -p {output_dir}/history/{config_suffix}/{sub_path}")
-			os.system(f"cp {output_dir}/{sub_path}/* {output_dir}/history/{config_suffix}/{sub_path}")
-		os.system(f"cp {output_dir}/config_flow/{os.path.splitext(os.path.basename(config_flow))[0]}_{suffix}_{config_suffix-1}.yml {output_dir}/history/{config_suffix}")
-
-#___________________________________________________________________________________________________________________________
-	# calculate the pT weights
-	if calc_weights:
-		check_dir(f"{output_dir}/ptweights")
-		CalcWeiPath = "./ComputePtWeights.py"
-
-		print(f"\033[32mpython3 {CalcWeiPath} {config_flow} -o {output_dir} -s {suffix}\033[0m")
-		os.system(f"python3 {CalcWeiPath} {config_flow} -o {output_dir} -s {suffix}")
-	else:
-		print("\033[33mWARNING: Calculation of weights will not be performed\033[0m")
-
-	if 'ptWeights_path' in config and config['ptWeights_path'] != '':
-		given_ptweights = True
-		given_ptWeightsPath = config['ptWeights_path']
-		print(f"\033[32mINFO: Given pt weights {given_ptWeightsPath} will be used\033[0m")
-	else:
-		given_ptweights = False
+    # backup the results into history
+    file_to_check = f"{output_dir}/V2VsFrac/V2VsFrac_{suffix}.root"
+    if os.path.exists(file_to_check):
+        for sub_path in ['ry', 'CutVarFrac', 'V2VsFrac']:
+            os.system(f"mkdir -p {output_dir}/history/{config_suffix}/{sub_path}")
+            os.system(f"cp {output_dir}/{sub_path}/* {output_dir}/history/{config_suffix}/{sub_path}")
+        os.system(f"cp {output_dir}/config_flow/{os.path.splitext(os.path.basename(config_flow))[0]}_{suffix}_{config_suffix-1}.yml {output_dir}/history/{config_suffix}")
 
 #___________________________________________________________________________________________________________________________
-	# make yaml file
-	if make_yaml:
-		check_dir(f"{output_dir}/config")
-		MakeyamlPath = './make_yaml_for_ml.py'
-		pre_process = "--preprocessed" if use_preprocessed else ""
+    # calculate the pT weights
+    if calc_weights:
+        check_dir(f"{output_dir}/ptweights")
+        CalcWeiPath = "./ComputePtWeights.py"
 
-		print(f"\033[32mpython3 {MakeyamlPath} {config_flow} {pre_process} -o {output_dir} -s {suffix}\033[0m")
-		os.system(f"python3 {MakeyamlPath} {config_flow} {pre_process} -o {output_dir} -s {suffix}")
-	else:
-		print("\033[33mWARNING: Make yaml will not be performed\033[0m")
+        print(f"\033[32mpython3 {CalcWeiPath} {config_flow} -o {output_dir} -s {suffix}\033[0m")
+        os.system(f"python3 {CalcWeiPath} {config_flow} -o {output_dir} -s {suffix}")
+    else:
+        print("\033[33mWARNING: Calculation of weights will not be performed\033[0m")
 
-#___________________________________________________________________________________________________________________________
-	# Projection for MC and apply the ptweights
-	if proj:
-		ProjPath = "./proj_thn.py"
-		if use_preprocessed:
-			pre_process = "--preprocessed"
-		else:
-			pre_process = ""
-			anres_files = ' '.join(anres_dir)
-     	check_dir(f"{output_dir}/proj")
-		print('Projecting histograms')
-    	
-     	def run_projections(i):
-			"""Run simulation fit for a given cutset index."""
-			iCutSets = f"{i:02d}"
-			print(f"\033[32mProcessing cutset {iCutSets}...\033[0m")
-			if not os.path.exists(f'{output_dir}/ptweights/pTweight_{suffix}.root')  and not given_ptweights:
-				# REVIEW: add the list of anres files
-				print(f"\033[32mpython3 {ProjPath} {config_flow} {output_dir}/config/cutset_{suffix}_{iCutSets}.yml {anres_files} {pre_process} -c {cent} -r {res_file} -o {output_dir} -s {suffix}_{iCutSets}\033[0m")
-				os.system(f"python3 {ProjPath} {config_flow} {output_dir}/config/cutset_{suffix}_{iCutSets}.yml {anres_files} {pre_process} -c {cent} -r {res_file} -o {output_dir} -s {suffix}_{iCutSets}")
-			else:
-				if given_ptweights:
-					ptweightsPath = given_ptWeightsPath
-				else:
-					ptweightsPath = f'{output_dir}/ptweights/pTweight_{suffix}.root'
-
-				print(
-					f"\033[32mpython3 {ProjPath} {config_flow} {output_dir}/config/cutset_{suffix}_{iCutSets}.yml {anres_files} {pre_process} "
-					f"-w {ptweightsPath} hPtWeightsFONLLtimesTAMUDcent "
-					f"-wb {ptweightsPath} hPtWeightsFONLLtimesTAMUBcent "
-					f"-c {cent} -r {res_file} -o {output_dir} -s {suffix}_{iCutSets} \033[0m"
-				)
-    			# REVIEW: add the list of anres files
-				os.system(f"python3 {ProjPath} {config_flow} {output_dir}/config/cutset_{suffix}_{iCutSets}.yml {anres_files} {pre_process} "
-						f"-w {ptweightsPath} hPtWeightsFONLLtimesTAMUDcent "
-						f"-wb {ptweightsPath} hPtWeightsFONLLtimesTAMUBcent "
-						f"-c {cent} -r {res_file} -o {output_dir} -s {suffix}_{iCutSets}")
-
-		with concurrent.futures.ThreadPoolExecutor(max_workers=n_workers) as executor:
-			results_proj = list(executor.map(run_projections, range(mCutSets)))
-	else:
-		print("\033[33mWARNING: Projection for MC will not be performed\033[0m")							
+    if 'ptWeights_path' in config and config['ptWeights_path'] != '':
+        given_ptweights = True
+        given_ptWeightsPath = config['ptWeights_path']
+        print(f"\033[32mINFO: Given pt weights {given_ptWeightsPath} will be used\033[0m")
+    else:
+        given_ptweights = False
 
 #___________________________________________________________________________________________________________________________
-	# Compute the efficiency
-	if efficiency:
-		check_dir(f"{output_dir}/eff")
-		EffPath = "./../compute_efficiency.py"
+    # make yaml file
+    if make_yaml:
+        check_dir(f"{output_dir}/config")
+        MakeyamlPath = './make_yaml_for_ml.py'
+        pre_process = "--preprocessed" if use_preprocessed else ""
 
-		def run_efficiency(i):
-			"""Run efficiency computation for a given cutset index."""
-			iCutSets = f"{i:02d}"
-			print(f"\033[32mpython3 {EffPath} {config_flow} {output_dir}/proj/proj_{suffix}_{iCutSets}.root -c {cent} -o {output_dir} -s {suffix}_{iCutSets}\033[0m")
-			print(f"\033[32mProcessing cutset {iCutSets}\033[0m")
-			os.system(f"python3 {EffPath} {config_flow} {output_dir}/proj/proj_{suffix}_{iCutSets}.root -c {cent} -o {output_dir} -s {suffix}_{iCutSets} --batch")
-		
-  		with concurrent.futures.ThreadPoolExecutor(max_workers=n_workers) as executor:
-			results_eff = list(executor.map(run_efficiency, range(mCutSets)))
-	else:
-		print("\033[33mWARNING: Efficiency will not be performed\033[0m")
+        print(f"\033[32mpython3 {MakeyamlPath} {config_flow} {pre_process} -o {output_dir} -s {suffix}\033[0m")
+        os.system(f"python3 {MakeyamlPath} {config_flow} {pre_process} -o {output_dir} -s {suffix}")
+    else:
+        print("\033[33mWARNING: Make yaml will not be performed\033[0m")
 
 #___________________________________________________________________________________________________________________________
-	# do the simulation fit to get the raw yields
-	if vn:
-		check_dir(f"{output_dir}/ry")
-		SimFitPath = "./../get_vn_vs_mass.py"
+    # Projection for MC and apply the ptweights
+    if proj:
+        check_dir(f"{output_dir}/proj")
+        ProjPath = "./proj_thn.py"
+        pre_process = "--preprocessed" if use_preprocessed else ""
+        anres_files = ' '.join(anres_dir)
 
-		def run_simfit(i):
-			"""Run simulation fit for a given cutset index."""
-			iCutSets = f"{i:02d}"
-			print(f"\033[32mpython3 {SimFitPath} {config_flow} {cent} {output_dir}/proj/proj_{suffix}.root -o {output_dir}/ry -s _{suffix}_{iCutSets} -vn {vn_method}\033[0m")
-			print(f"\033[32mProcessing cutset {iCutSets}\033[0m")
-			os.system(f"python3 {SimFitPath} {config_flow} {cent} {output_dir}/proj/proj_{suffix}_{iCutSets}.root -o {output_dir}/ry -s _{suffix}_{iCutSets} -vn {vn_method} --batch")
-		
-  		with concurrent.futures.ThreadPoolExecutor(max_workers=n_workers) as executor:
-			executor.map(run_simfit, range(mCutSets))
-	else:
-		print("\033[33mWARNING: vn extraction will not be performed\033[0m")
+        def run_projections(i):
+            """Run simulation fit for a given cutset index."""
+            iCutSets = f"{i:02d}"
+            print(f"\033[32mProcessing cutset {iCutSets}...\033[0m")
 
-#___________________________________________________________________________________________________________________________
-	# Compute the fraction by cut variation method
-	if frac_cut_var:
-		check_dir(f"{output_dir}/CutVarFrac")
-		CurVarFracPath = "./compute_frac_cut_var.py"
+            if not os.path.exists(f"{output_dir}/ptweights/pTweight_{suffix}.root") and not given_ptweights:
+                # REVIEW: add the list of anres files
+                cmd = (
+                    f"python3 {ProjPath} {config_flow} {output_dir}/config/cutset_{suffix}_{iCutSets}.yml {anres_files} {pre_process} "
+                    f"-c {cent} -r {res_file} -o {output_dir} -s {suffix}_{iCutSets}"
+                )
+            else:
+                ptweightsPath = given_ptWeightsPath if given_ptweights else f"{output_dir}/ptweights/pTweight_{suffix}.root"
 
-		print(f"\033[32mpython3 {CurVarFracPath} {config_flow} {output_dir} -o {output_dir} -s {suffix}\033[0m")
-		os.system(f"python3 {CurVarFracPath} {config_flow} {output_dir} -o {output_dir} -s {suffix} --batch")
-	else:
-		print("\033[33mWARNING: Fraction by cut variation will not be performed\033[0m")
+                cmd = (
+                    f"python3 {ProjPath} {config_flow} {output_dir}/config/cutset_{suffix}_{iCutSets}.yml {anres_files} {pre_process} "
+                    f"-w {ptweightsPath} hPtWeightsFONLLtimesTAMUDcent "
+                    f"-wb {ptweightsPath} hPtWeightsFONLLtimesTAMUBcent "
+                    f"-c {cent} -r {res_file} -o {output_dir} -s {suffix}_{iCutSets}"
+                )
+            
+            print(f"\033[32m{cmd}\033[0m")
+            os.system(cmd)
 
-#___________________________________________________________________________________________________________________________
-	# Compute fraction by Data-driven method
-	if data_driven_frac:
-		check_dir(f"{output_dir}/DataDrivenFrac")
-		DataDrivenFracPath = "./ComputeDataDriFrac_flow.py"
+        with concurrent.futures.ThreadPoolExecutor(max_workers=n_workers) as executor:
+            results_proj = list(executor.map(run_projections, range(mCutSets)))
+    else:
+        print("\033[33mWARNING: Projection for MC will not be performed\033[0m")
 
-		# TODO: add the combined method with runing the correlated and uncorrelated at the same time
-		combined = config['combined'] if 'combined' in config else False
-		print(f"\033[32mCombined method: {combined}\033[0m")
-		if combined:
-			if config['minimisation']['correlated']:
-				print("\033[31mOnly support combined method when the minimisation is uncorrelated\033[0m")
-				print("\033[31mThe combined method will not be performed\033[0m")
-				# run the data-driven method with the corelated results
-				print(f"\033[32mpython3 {DataDrivenFracPath} -i {output_dir} -o {output_dir} -s {suffix} -b\033[0m")
-				main_data_driven_frac(inputdir=output_dir, outputdir=output_dir, suffix=suffix, batch=True, combined=False)
-			else:
-				# the path of corresponding results with correlated cut method
-				correlatedPath = config['correlatedPath'] if 'correlatedPath' in config else ''
-				if correlatedPath == '':
-					print("\033[31mPlease provide the path to the corresponding correlated cut method\033[0m")
-					correlatedPath = input("Path(`output_dir` in run_cutvar.sh): ")
-				correlatedCutVarPath = correlatedPath + '/cutvar_' + suffix
-				
-				# the path of the combined results
-				if 'pass3' in correlatedPath:
-					outputdir_corr = output_dir.replace(f'{output_dir.split("/")[-2]}', 'combined_pass3')
-				else:
-					outputdir_corr = output_dir.replace(f'{output_dir.split("/")[-2]}', 'combined')
-				check_dir(f"{outputdir_corr}/DataDrivenFrac")
-				
-				# run the data-driven method with the combined results and the uncorrelated results
-				print(f"\033[32mpython3 {DataDrivenFracPath} -i {output_dir} -o {output_dir} -s {suffix} -b -comb -cc {correlatedCutVarPath} -oc {outputdir_corr}\033[0m") 
-				main_data_driven_frac(inputdir=output_dir, outputdir=output_dir, suffix=suffix, batch=True, \
-										combined=True, correlatedCutVarPath=correlatedCutVarPath, outputdir_combined=outputdir_corr)
-
-		# run the data-driven method with the uncorrelated or correlated results
-		else:
-			print(f"\033[32mpython3 {DataDrivenFracPath} -i {output_dir} -o {output_dir} -s {suffix} -b\033[0m")
-			main_data_driven_frac(inputdir=output_dir, outputdir=output_dir, suffix=suffix, batch=True, combined=False)
-
-	else:
-		print("\033[33mWARNING: Fraction by Data-driven method will not be performed\033[0m")
 
 #___________________________________________________________________________________________________________________________
-	# Compute v2 vs fraction
-	if v2_vs_frac:
-		check_dir(f"{output_dir}/V2VsFrac")
-		v2vsFDFracPath = "./ComputeV2vsFDFrac.py"
-		
-		combined = config['combined'] if 'combined' in config else False
-		
-		if combined:
-			if 'pass3' in output_dir:
-				inputdir_combined = output_dir.replace(f'{output_dir.split("/")[-2]}', 'combined_pass3')
-			else:
-				inputdir_combined = output_dir.replace(f'{output_dir.split("/")[-2]}', 'combined')
-			outputdir_combined = inputdir_combined
-			check_dir(f"{outputdir_combined}/V2VsFrac")
-			
-			print(f"\033[32mthe combined method will be performed\033[0m")
-			print(f"\033[32mpython3 {v2vsFDFracPath} {config_flow} -i {output_dir} -o {output_dir} -s {suffix} -comb -ic {inputdir_combined} -oc {outputdir_combined}\033[0m")
-			main_v2_vs_frac(config=config_flow, inputdir=output_dir, outputdir=output_dir, suffix=suffix, \
-								combined=True, inputdir_combined=inputdir_combined, outputdir_combined=outputdir_combined)
-		else:
-			print(f"\033[32mpython3 {v2vsFDFracPath} {config_flow} -i {output_dir} -o {output_dir} -s {suffix}\033[0m")
-			main_v2_vs_frac(config=config_flow, inputdir=output_dir, outputdir=output_dir, suffix=suffix, combined=False)
-	else:
-		print("\033[33mWARNING: v2 vs fraction will not be performed\033[0m")
+    # Compute the efficiency
+    if efficiency:
+        check_dir(f"{output_dir}/eff")
+        EffPath = "./../compute_efficiency.py"
+
+        def run_efficiency(i):
+            """Run efficiency computation for a given cutset index."""
+            iCutSets = f"{i:02d}"
+            print(f"\033[32mpython3 {EffPath} {config_flow} {output_dir}/proj/proj_{suffix}_{iCutSets}.root -c {cent} -o {output_dir} -s {suffix}_{iCutSets}\033[0m")
+            print(f"\033[32mProcessing cutset {iCutSets}\033[0m")
+            os.system(f"python3 {EffPath} {config_flow} {output_dir}/proj/proj_{suffix}_{iCutSets}.root -c {cent} -o {output_dir} -s {suffix}_{iCutSets} --batch")
+        
+        with concurrent.futures.ThreadPoolExecutor(max_workers=n_workers) as executor:
+            results_eff = list(executor.map(run_efficiency, range(mCutSets)))
+    else:
+        print("\033[33mWARNING: Efficiency will not be performed\033[0m")
 
 #___________________________________________________________________________________________________________________________
-	# Merge cut var figures in multipanel images
-	if merge_images:
-		print(f"\033[32m\nCut_var_image_merger({config_flow}, {output_dir}, {suffix})\033[0m")
-		cut_var_image_merger(config, output_dir, suffix)
-	return
+    # do the simulation fit to get the raw yields
+    if vn:
+        check_dir(f"{output_dir}/ry")
+        SimFitPath = "./../get_vn_vs_mass.py"
+
+        def run_simfit(i):
+            """Run simulation fit for a given cutset index."""
+            iCutSets = f"{i:02d}"
+            print(f"\033[32mpython3 {SimFitPath} {config_flow} {cent} {output_dir}/proj/proj_{suffix}.root -o {output_dir}/ry -s _{suffix}_{iCutSets} -vn {vn_method}\033[0m")
+            print(f"\033[32mProcessing cutset {iCutSets}\033[0m")
+            os.system(f"python3 {SimFitPath} {config_flow} {cent} {output_dir}/proj/proj_{suffix}_{iCutSets}.root -o {output_dir}/ry -s _{suffix}_{iCutSets} -vn {vn_method} --batch")
+        
+        with concurrent.futures.ThreadPoolExecutor(max_workers=n_workers) as executor:
+            executor.map(run_simfit, range(mCutSets))
+    else:
+        print("\033[33mWARNING: vn extraction will not be performed\033[0m")
+
+#___________________________________________________________________________________________________________________________
+    # Compute the fraction by cut variation method
+    if frac_cut_var:
+        check_dir(f"{output_dir}/CutVarFrac")
+        CurVarFracPath = "./compute_frac_cut_var.py"
+
+        print(f"\033[32mpython3 {CurVarFracPath} {config_flow} {output_dir} -o {output_dir} -s {suffix}\033[0m")
+        os.system(f"python3 {CurVarFracPath} {config_flow} {output_dir} -o {output_dir} -s {suffix} --batch")
+    else:
+        print("\033[33mWARNING: Fraction by cut variation will not be performed\033[0m")
+
+#___________________________________________________________________________________________________________________________
+    # Compute fraction by Data-driven method
+    if data_driven_frac:
+        check_dir(f"{output_dir}/DataDrivenFrac")
+        DataDrivenFracPath = "./ComputeDataDriFrac_flow.py"
+
+        # TODO: add the combined method with runing the correlated and uncorrelated at the same time
+        combined = config['combined'] if 'combined' in config else False
+        print(f"\033[32mCombined method: {combined}\033[0m")
+        if combined:
+            if config['minimisation']['correlated']:
+                print("\033[31mOnly support combined method when the minimisation is uncorrelated\033[0m")
+                print("\033[31mThe combined method will not be performed\033[0m")
+                # run the data-driven method with the corelated results
+                print(f"\033[32mpython3 {DataDrivenFracPath} -i {output_dir} -o {output_dir} -s {suffix} -b\033[0m")
+                main_data_driven_frac(inputdir=output_dir, outputdir=output_dir, suffix=suffix, batch=True, combined=False)
+            else:
+                # the path of corresponding results with correlated cut method
+                correlatedPath = config['correlatedPath'] if 'correlatedPath' in config else ''
+                if correlatedPath == '':
+                    print("\033[31mPlease provide the path to the corresponding correlated cut method\033[0m")
+                    correlatedPath = input("Path(`output_dir` in run_cutvar.sh): ")
+                correlatedCutVarPath = correlatedPath + '/cutvar_' + suffix
+                
+                # the path of the combined results
+                if 'pass3' in correlatedPath:
+                    outputdir_corr = output_dir.replace(f'{output_dir.split("/")[-2]}', 'combined_pass3')
+                else:
+                    outputdir_corr = output_dir.replace(f'{output_dir.split("/")[-2]}', 'combined')
+                check_dir(f"{outputdir_corr}/DataDrivenFrac")
+                
+                # run the data-driven method with the combined results and the uncorrelated results
+                print(f"\033[32mpython3 {DataDrivenFracPath} -i {output_dir} -o {output_dir} -s {suffix} -b -comb -cc {correlatedCutVarPath} -oc {outputdir_corr}\033[0m") 
+                main_data_driven_frac(inputdir=output_dir, outputdir=output_dir, suffix=suffix, batch=True, \
+                                        combined=True, correlatedCutVarPath=correlatedCutVarPath, outputdir_combined=outputdir_corr)
+
+        # run the data-driven method with the uncorrelated or correlated results
+        else:
+            print(f"\033[32mpython3 {DataDrivenFracPath} -i {output_dir} -o {output_dir} -s {suffix} -b\033[0m")
+            main_data_driven_frac(inputdir=output_dir, outputdir=output_dir, suffix=suffix, batch=True, combined=False)
+
+    else:
+        print("\033[33mWARNING: Fraction by Data-driven method will not be performed\033[0m")
+
+#___________________________________________________________________________________________________________________________
+    # Compute v2 vs fraction
+    if v2_vs_frac:
+        check_dir(f"{output_dir}/V2VsFrac")
+        v2vsFDFracPath = "./ComputeV2vsFDFrac.py"
+        
+        combined = config['combined'] if 'combined' in config else False
+        
+        if combined:
+            if 'pass3' in output_dir:
+                inputdir_combined = output_dir.replace(f'{output_dir.split("/")[-2]}', 'combined_pass3')
+            else:
+                inputdir_combined = output_dir.replace(f'{output_dir.split("/")[-2]}', 'combined')
+            outputdir_combined = inputdir_combined
+            check_dir(f"{outputdir_combined}/V2VsFrac")
+            
+            print(f"\033[32mthe combined method will be performed\033[0m")
+            print(f"\033[32mpython3 {v2vsFDFracPath} {config_flow} -i {output_dir} -o {output_dir} -s {suffix} -comb -ic {inputdir_combined} -oc {outputdir_combined}\033[0m")
+            main_v2_vs_frac(config=config_flow, inputdir=output_dir, outputdir=output_dir, suffix=suffix, \
+                                combined=True, inputdir_combined=inputdir_combined, outputdir_combined=outputdir_combined)
+        else:
+            print(f"\033[32mpython3 {v2vsFDFracPath} {config_flow} -i {output_dir} -o {output_dir} -s {suffix}\033[0m")
+            main_v2_vs_frac(config=config_flow, inputdir=output_dir, outputdir=output_dir, suffix=suffix, combined=False)
+    else:
+        print("\033[33mWARNING: v2 vs fraction will not be performed\033[0m")
+
+#___________________________________________________________________________________________________________________________
+    # Merge cut var figures in multipanel images
+    if merge_images:
+        print(f"\033[32m\nCut_var_image_merger({config_flow}, {output_dir}, {suffix})\033[0m")
+        cut_var_image_merger(config, output_dir, suffix)
+    return
 
 
 if __name__ == "__main__":
-	parser = argparse.ArgumentParser(description='Arguments')
-	parser.add_argument('flow_config', metavar='text', default='config_flow_d0.yml', help='configuration file')
-	parser.add_argument("--preprocessed", "-prep", action="store_true", help="use preprocessed input")
-	parser.add_argument("--do_calc_weights", "-cw", action="store_true", help="perform calculation of weights")
-	parser.add_argument("--do_make_yaml", "-my", action="store_true", help="perform make yaml")
-	parser.add_argument("--do_projections", "-pd", action="store_true", help="perform projections")
-	parser.add_argument("--do_efficiency", "-e", action="store_true", help="perform efficiency")
-	parser.add_argument("--do_vn", "-vn", action="store_true", help="perform vn extraction")
-	parser.add_argument("--do_frac_cut_var", "-f", action="store_true", help="perform fraction by cut variation")
-	parser.add_argument("--do_data_driven_frac", "-ddf", action="store_true", help="perform fraction by data-driven method")
-	parser.add_argument("--do_v2_vs_frac", "-v2fd", action="store_true", help="perform v2 vs FD fraction")
-	parser.add_argument("--do_merge_images", "-mergeim", action="store_true", help="perform v2 vs FD fraction")
-	args = parser.parse_args()
+    parser = argparse.ArgumentParser(description='Arguments')
+    parser.add_argument('flow_config', metavar='text', default='config_flow_d0.yml', help='configuration file')
+    parser.add_argument("--preprocessed", "-prep", action="store_true", help="use preprocessed input")
+    parser.add_argument("--do_calc_weights", "-cw", action="store_true", help="perform calculation of weights")
+    parser.add_argument("--do_make_yaml", "-my", action="store_true", help="perform make yaml")
+    parser.add_argument("--do_projections", "-pd", action="store_true", help="perform projections")
+    parser.add_argument("--do_efficiency", "-e", action="store_true", help="perform efficiency")
+    parser.add_argument("--do_vn", "-vn", action="store_true", help="perform vn extraction")
+    parser.add_argument("--do_frac_cut_var", "-f", action="store_true", help="perform fraction by cut variation")
+    parser.add_argument("--do_data_driven_frac", "-ddf", action="store_true", help="perform fraction by data-driven method")
+    parser.add_argument("--do_v2_vs_frac", "-v2fd", action="store_true", help="perform v2 vs FD fraction")
+    parser.add_argument("--do_merge_images", "-mergeim", action="store_true", help="perform v2 vs FD fraction")
+    args = parser.parse_args()
 
-	start_time = time.time()
-	run_full_cut_variation(args.flow_config,
+    start_time = time.time()
+    print(f"args.do_projections: {args.do_projections}")
+    run_full_cut_variation(args.flow_config,
                            args.preprocessed,
-						   args.do_calc_weights,
-						   args.do_make_yaml, 
-						   args.do_projections,
-						   args.do_efficiency, 
-						   args.do_vn,
-						   args.do_frac_cut_var, 
-						   args.do_data_driven_frac, 
-						   args.do_v2_vs_frac,
-						   args.do_merge_images)
+                           args.do_calc_weights,
+                           args.do_make_yaml, 
+                           args.do_projections,
+                           args.do_efficiency, 
+                           args.do_vn,
+                           args.do_frac_cut_var, 
+                           args.do_data_driven_frac, 
+                           args.do_v2_vs_frac,
+                           args.do_merge_images)
 
-	end_time = time.time()
-	execution_time = end_time - start_time
-	print(f"\033[34mTotal execution time: {execution_time:.2f} seconds\033[0m")
+    end_time = time.time()
+    execution_time = end_time - start_time
+    print(f"\033[34mTotal execution time: {execution_time:.2f} seconds\033[0m")
  

--- a/run3/flow/BDT/run_cutvar.py
+++ b/run3/flow/BDT/run_cutvar.py
@@ -6,6 +6,7 @@ import yaml
 import shutil
 import concurrent.futures
 import time
+import subprocess
 sys.path.append('..')
 from flow_analysis_utils import get_cut_sets_config, cut_var_image_merger
 from ComputeDataDriFrac_flow import main_data_driven_frac
@@ -34,7 +35,7 @@ def run_full_cut_variation(config_flow,
 						   frac_cut_var=False,
 						   data_driven_frac=False,
 						   v2_vs_frac=False,
-							merge_images=False):    
+						   merge_images=False):    
 #___________________________________________________________________________________________________________________________
 	# Load and copy the configuration file
 	with open(config_flow, 'r') as cfgFlow:
@@ -57,13 +58,18 @@ def run_full_cut_variation(config_flow,
 	output_dir = f"{output}/cutvar_{suffix}"
  
 	os.system(f"mkdir -p {output_dir}")
-  
 	# copy the configuration file
 	config_suffix = 0
 	os.makedirs(f'{output_dir}/config_flow', exist_ok=True)
-	while os.path.exists(f'{output_dir}/config_flow/config_flow_{suffix}_{config_suffix}.yml'):
+	while os.path.exists(f'{output_dir}/config_flow/{os.path.splitext(os.path.basename(config_flow))[0]}_{suffix}_{config_suffix}.yml'):
 		config_suffix = config_suffix + 1
-	os.system(f'cp {config_flow} {output_dir}/{os.path.splitext(os.path.basename(config_flow))[0]}_{suffix}_{config_suffix}.yml')
+	os.system(f'cp {config_flow} {output_dir}/config_flow/{os.path.splitext(os.path.basename(config_flow))[0]}_{suffix}_{config_suffix}.yml')
+
+	# Create log file
+	os.makedirs(f"{output_dir}/logs", exist_ok=True)
+	log_file = f"{output_dir}/logs/log_{config_suffix}.log"
+	sys.stdout = open(log_file, "a")
+	sys.stderr = sys.stdout
 
 	# backup the results into history
 	file_to_check = f"{output_dir}/V2VsFrac/V2VsFrac_{suffix}.root"
@@ -80,7 +86,7 @@ def run_full_cut_variation(config_flow,
 		CalcWeiPath = "./ComputePtWeights.py"
 
 		print(f"\033[32mpython3 {CalcWeiPath} {config_flow} -o {output_dir} -s {suffix}\033[0m")
-		os.system(f"python3 {CalcWeiPath} {config_flow} -o {output_dir} -s {suffix}")
+		os.system(f"python3 {CalcWeiPath} {config_flow} -o {output_dir} -s {suffix} >> {log_file} 2>&1")
 	else:
 		print("\033[33mWARNING: Calculation of weights will not be performed\033[0m")
 
@@ -99,7 +105,7 @@ def run_full_cut_variation(config_flow,
 		pre_process = "--preprocessed" if use_preprocessed else ""
 
 		print(f"\033[32mpython3 {MakeyamlPath} {config_flow} {pre_process} -o {output_dir} -s {suffix}\033[0m")
-		os.system(f"python3 {MakeyamlPath} {config_flow} {pre_process} -o {output_dir} -s {suffix}")
+		os.system(f"python3 {MakeyamlPath} {config_flow} {pre_process} -o {output_dir} -s {suffix} >> {log_file} 2>&1")
 	else:
 		print("\033[33mWARNING: Make yaml will not be performed\033[0m")
 
@@ -112,7 +118,7 @@ def run_full_cut_variation(config_flow,
 		anres_files = ' '.join(anres_dir)
 
 		def run_projections(i):
-			"""Run simulation fit for a given cutset index."""
+			"""Run sparse projection for a given cutset index."""
 			iCutSets = f"{i:02d}"
 			print(f"\033[32mProcessing cutset {iCutSets}...\033[0m")
 
@@ -120,7 +126,7 @@ def run_full_cut_variation(config_flow,
 				# REVIEW: add the list of anres files
 				cmd = (
 					f"python3 {ProjPath} {config_flow} {output_dir}/config/cutset_{suffix}_{iCutSets}.yml {anres_files} {pre_process} "
-					f"-c {cent} -r {res_file} -o {output_dir} -s {suffix}_{iCutSets}"
+					f"-c {cent} -r {res_file} -o {output_dir} -s {suffix}_{iCutSets} >> {log_file} 2>&1"
 				)
 			else:
 				ptweightsPath = given_ptWeightsPath if given_ptweights else f"{output_dir}/ptweights/pTweight_{suffix}.root"
@@ -129,7 +135,7 @@ def run_full_cut_variation(config_flow,
 					f"python3 {ProjPath} {config_flow} {output_dir}/config/cutset_{suffix}_{iCutSets}.yml {anres_files} {pre_process} "
 					f"-w {ptweightsPath} hPtWeightsFONLLtimesTAMUDcent "
 					f"-wb {ptweightsPath} hPtWeightsFONLLtimesTAMUBcent "
-					f"-c {cent} -r {res_file} -o {output_dir} -s {suffix}_{iCutSets}"
+					f"-c {cent} -r {res_file} -o {output_dir} -s {suffix}_{iCutSets} >> {log_file} 2>&1"
 				)
 			
 			print(f"\033[32m{cmd}\033[0m")
@@ -152,7 +158,7 @@ def run_full_cut_variation(config_flow,
 			iCutSets = f"{i:02d}"
 			print(f"\033[32mpython3 {EffPath} {config_flow} {output_dir}/proj/proj_{suffix}_{iCutSets}.root -c {cent} -o {output_dir} -s {suffix}_{iCutSets}\033[0m")
 			print(f"\033[32mProcessing cutset {iCutSets}\033[0m")
-			os.system(f"python3 {EffPath} {config_flow} {output_dir}/proj/proj_{suffix}_{iCutSets}.root -c {cent} -o {output_dir} -s {suffix}_{iCutSets} --batch")
+			os.system(f"python3 {EffPath} {config_flow} {output_dir}/proj/proj_{suffix}_{iCutSets}.root -c {cent} -o {output_dir} -s {suffix}_{iCutSets} --batch >> {log_file} 2>&1")
 		
 		with concurrent.futures.ThreadPoolExecutor(max_workers=n_workers) as executor:
 			results_eff = list(executor.map(run_efficiency, range(mCutSets)))
@@ -166,11 +172,11 @@ def run_full_cut_variation(config_flow,
 		SimFitPath = "./../get_vn_vs_mass.py"
 
 		def run_simfit(i):
-			"""Run simulation fit for a given cutset index."""
+			"""Run simultaneous fit for a given cutset index."""
 			iCutSets = f"{i:02d}"
 			print(f"\033[32mpython3 {SimFitPath} {config_flow} {cent} {output_dir}/proj/proj_{suffix}.root -o {output_dir}/ry -s _{suffix}_{iCutSets} -vn {vn_method}\033[0m")
 			print(f"\033[32mProcessing cutset {iCutSets}\033[0m")
-			os.system(f"python3 {SimFitPath} {config_flow} {cent} {output_dir}/proj/proj_{suffix}_{iCutSets}.root -o {output_dir}/ry -s _{suffix}_{iCutSets} -vn {vn_method} --batch")
+			os.system(f"python3 {SimFitPath} {config_flow} {cent} {output_dir}/proj/proj_{suffix}_{iCutSets}.root -o {output_dir}/ry -s _{suffix}_{iCutSets} -vn {vn_method} --batch >> {log_file} 2>&1")
 		
 		with concurrent.futures.ThreadPoolExecutor(max_workers=n_workers) as executor:
 			executor.map(run_simfit, range(mCutSets))
@@ -184,7 +190,7 @@ def run_full_cut_variation(config_flow,
 		CurVarFracPath = "./compute_frac_cut_var.py"
 
 		print(f"\033[32mpython3 {CurVarFracPath} {config_flow} {output_dir} -o {output_dir} -s {suffix}\033[0m")
-		os.system(f"python3 {CurVarFracPath} {config_flow} {output_dir} -o {output_dir} -s {suffix} --batch")
+		os.system(f"python3 {CurVarFracPath} {config_flow} {output_dir} -o {output_dir} -s {suffix} --batch >> {log_file} 2>&1")
 	else:
 		print("\033[33mWARNING: Fraction by cut variation will not be performed\033[0m")
 
@@ -263,13 +269,20 @@ def run_full_cut_variation(config_flow,
 	if merge_images:
 		print(f"\033[32m\nCut_var_image_merger({config_flow}, {output_dir}, {suffix})\033[0m")
 		cut_var_image_merger(config, output_dir, suffix)
+
+	# Run the clean_logs.py script with the log file as an argument
+	script_dir = os.path.dirname(os.path.realpath(__file__))
+	clean_logs_script = f"{script_dir}/../../tool/clean_logs.py"
+	subprocess.run(["python3", clean_logs_script, log_file])
+	print(f"Log saved to: {log_file}")
+
 	return
 
 
 if __name__ == "__main__":
 	parser = argparse.ArgumentParser(description='Arguments')
 	parser.add_argument('flow_config', metavar='text', default='config_flow_d0.yml', help='configuration file')
-	parser.add_argument("--preprocessed", "-prep", action="store_true", help="use preprocessed input")
+	parser.add_argument("--use_preprocessed", "-prep", action="store_true", help="use preprocessed input")
 	parser.add_argument("--do_calc_weights", "-cw", action="store_true", help="perform calculation of weights")
 	parser.add_argument("--do_make_yaml", "-my", action="store_true", help="perform make yaml")
 	parser.add_argument("--do_projections", "-pd", action="store_true", help="perform projections")
@@ -282,9 +295,8 @@ if __name__ == "__main__":
 	args = parser.parse_args()
 
 	start_time = time.time()
-	print(f"args.do_projections: {args.do_projections}")
 	run_full_cut_variation(args.flow_config,
-						   args.preprocessed,
+						   args.use_preprocessed,
 						   args.do_calc_weights,
 						   args.do_make_yaml, 
 						   args.do_projections,
@@ -297,5 +309,8 @@ if __name__ == "__main__":
 
 	end_time = time.time()
 	execution_time = end_time - start_time
+	sys.stdout.close()
+	sys.stdout = sys.__stdout__
+	sys.stderr = sys.__stderr__
 	print(f"\033[34mTotal execution time: {execution_time:.2f} seconds\033[0m")
  

--- a/run3/flow/BDT/run_cutvar.py
+++ b/run3/flow/BDT/run_cutvar.py
@@ -14,288 +14,288 @@ from concurrent.futures import ProcessPoolExecutor
 
 def check_dir(dir):
 
-    if not os.path.exists(dir):
-        print(f"\033[32m{dir} does not exist, it will be created\033[0m")
-        os.makedirs(dir)
-    else:
-        print(f"\033[33m{dir} already exists, it will be removed and recreated\033[0m")
-        shutil.rmtree(dir)
-        os.makedirs(dir)
+	if not os.path.exists(dir):
+		print(f"\033[32m{dir} does not exist, it will be created\033[0m")
+		os.makedirs(dir)
+	else:
+		print(f"\033[33m{dir} already exists, it will be removed and recreated\033[0m")
+		shutil.rmtree(dir)
+		os.makedirs(dir)
 
-    return
+	return
 
 def run_full_cut_variation(config_flow,
-                           use_preprocessed, 
-                           calc_weights=False,
-                           make_yaml=False, 
-                           proj=False,
-                           efficiency=False,
-                           vn = False,
-                           frac_cut_var=False,
-                           data_driven_frac=False,
-                           v2_vs_frac=False,
-                            merge_images=False):    
+						   use_preprocessed, 
+						   calc_weights=False,
+						   make_yaml=False, 
+						   proj=False,
+						   efficiency=False,
+						   vn = False,
+						   frac_cut_var=False,
+						   data_driven_frac=False,
+						   v2_vs_frac=False,
+							merge_images=False):    
 #___________________________________________________________________________________________________________________________
-    # Load and copy the configuration file
-    with open(config_flow, 'r') as cfgFlow:
-        config = yaml.safe_load(cfgFlow)
+	# Load and copy the configuration file
+	with open(config_flow, 'r') as cfgFlow:
+		config = yaml.safe_load(cfgFlow)
 
-    anres_dir = config['anresdir'] 
-    cent = config['centrality'] 
-    res_file = config['res_file'] 
-    output = config['out_dir'] 
-    suffix = config['suffix'] 
-    vn_method = config['vn_method']
-    n_workers = config['nworkers']
+	anres_dir = config['anresdir'] 
+	cent = config['centrality'] 
+	res_file = config['res_file'] 
+	output = config['out_dir'] 
+	suffix = config['suffix'] 
+	vn_method = config['vn_method']
+	n_workers = config['nworkers']
 
-    CutSets, _, _, _, _ = get_cut_sets_config(config_flow)
-    # REVIEW: uniformize the max cutsets variable
-    mCutSets = max(CutSets)
+	CutSets, _, _, _, _ = get_cut_sets_config(config_flow)
+	# REVIEW: uniformize the max cutsets variable
+	mCutSets = max(CutSets)
 
-    print(f"\033[32mINFO: Number of cutsets: {mCutSets}\033[0m")
+	print(f"\033[32mINFO: Number of cutsets: {mCutSets}\033[0m")
 
-    output_dir = f"{output}/cutvar_{suffix}"
+	output_dir = f"{output}/cutvar_{suffix}"
  
-    os.system(f"mkdir -p {output_dir}")
+	os.system(f"mkdir -p {output_dir}")
   
-    # copy the configuration file
-    config_suffix = 0
-    os.makedirs(f'{output_dir}/config_flow', exist_ok=True)
-    while os.path.exists(f'{output_dir}/config_flow/config_flow_{suffix}_{config_suffix}.yml'):
-        config_suffix = config_suffix + 1
-    os.system(f'cp {config_flow} {output_dir}/{os.path.splitext(os.path.basename(config_flow))[0]}_{suffix}_{config_suffix}.yml')
+	# copy the configuration file
+	config_suffix = 0
+	os.makedirs(f'{output_dir}/config_flow', exist_ok=True)
+	while os.path.exists(f'{output_dir}/config_flow/config_flow_{suffix}_{config_suffix}.yml'):
+		config_suffix = config_suffix + 1
+	os.system(f'cp {config_flow} {output_dir}/{os.path.splitext(os.path.basename(config_flow))[0]}_{suffix}_{config_suffix}.yml')
 
-    # backup the results into history
-    file_to_check = f"{output_dir}/V2VsFrac/V2VsFrac_{suffix}.root"
-    if os.path.exists(file_to_check):
-        for sub_path in ['ry', 'CutVarFrac', 'V2VsFrac']:
-            os.system(f"mkdir -p {output_dir}/history/{config_suffix}/{sub_path}")
-            os.system(f"cp {output_dir}/{sub_path}/* {output_dir}/history/{config_suffix}/{sub_path}")
-        os.system(f"cp {output_dir}/config_flow/{os.path.splitext(os.path.basename(config_flow))[0]}_{suffix}_{config_suffix-1}.yml {output_dir}/history/{config_suffix}")
-
-#___________________________________________________________________________________________________________________________
-    # calculate the pT weights
-    if calc_weights:
-        check_dir(f"{output_dir}/ptweights")
-        CalcWeiPath = "./ComputePtWeights.py"
-
-        print(f"\033[32mpython3 {CalcWeiPath} {config_flow} -o {output_dir} -s {suffix}\033[0m")
-        os.system(f"python3 {CalcWeiPath} {config_flow} -o {output_dir} -s {suffix}")
-    else:
-        print("\033[33mWARNING: Calculation of weights will not be performed\033[0m")
-
-    if 'ptWeights_path' in config and config['ptWeights_path'] != '':
-        given_ptweights = True
-        given_ptWeightsPath = config['ptWeights_path']
-        print(f"\033[32mINFO: Given pt weights {given_ptWeightsPath} will be used\033[0m")
-    else:
-        given_ptweights = False
+	# backup the results into history
+	file_to_check = f"{output_dir}/V2VsFrac/V2VsFrac_{suffix}.root"
+	if os.path.exists(file_to_check):
+		for sub_path in ['ry', 'CutVarFrac', 'V2VsFrac']:
+			os.system(f"mkdir -p {output_dir}/history/{config_suffix}/{sub_path}")
+			os.system(f"cp {output_dir}/{sub_path}/* {output_dir}/history/{config_suffix}/{sub_path}")
+		os.system(f"cp {output_dir}/config_flow/{os.path.splitext(os.path.basename(config_flow))[0]}_{suffix}_{config_suffix-1}.yml {output_dir}/history/{config_suffix}")
 
 #___________________________________________________________________________________________________________________________
-    # make yaml file
-    if make_yaml:
-        check_dir(f"{output_dir}/config")
-        MakeyamlPath = './make_yaml_for_ml.py'
-        pre_process = "--preprocessed" if use_preprocessed else ""
+	# calculate the pT weights
+	if calc_weights:
+		check_dir(f"{output_dir}/ptweights")
+		CalcWeiPath = "./ComputePtWeights.py"
 
-        print(f"\033[32mpython3 {MakeyamlPath} {config_flow} {pre_process} -o {output_dir} -s {suffix}\033[0m")
-        os.system(f"python3 {MakeyamlPath} {config_flow} {pre_process} -o {output_dir} -s {suffix}")
-    else:
-        print("\033[33mWARNING: Make yaml will not be performed\033[0m")
+		print(f"\033[32mpython3 {CalcWeiPath} {config_flow} -o {output_dir} -s {suffix}\033[0m")
+		os.system(f"python3 {CalcWeiPath} {config_flow} -o {output_dir} -s {suffix}")
+	else:
+		print("\033[33mWARNING: Calculation of weights will not be performed\033[0m")
 
-#___________________________________________________________________________________________________________________________
-    # Projection for MC and apply the ptweights
-    if proj:
-        check_dir(f"{output_dir}/proj")
-        ProjPath = "./proj_thn.py"
-        pre_process = "--preprocessed" if use_preprocessed else ""
-        anres_files = ' '.join(anres_dir)
-
-        def run_projections(i):
-            """Run simulation fit for a given cutset index."""
-            iCutSets = f"{i:02d}"
-            print(f"\033[32mProcessing cutset {iCutSets}...\033[0m")
-
-            if not os.path.exists(f"{output_dir}/ptweights/pTweight_{suffix}.root") and not given_ptweights:
-                # REVIEW: add the list of anres files
-                cmd = (
-                    f"python3 {ProjPath} {config_flow} {output_dir}/config/cutset_{suffix}_{iCutSets}.yml {anres_files} {pre_process} "
-                    f"-c {cent} -r {res_file} -o {output_dir} -s {suffix}_{iCutSets}"
-                )
-            else:
-                ptweightsPath = given_ptWeightsPath if given_ptweights else f"{output_dir}/ptweights/pTweight_{suffix}.root"
-
-                cmd = (
-                    f"python3 {ProjPath} {config_flow} {output_dir}/config/cutset_{suffix}_{iCutSets}.yml {anres_files} {pre_process} "
-                    f"-w {ptweightsPath} hPtWeightsFONLLtimesTAMUDcent "
-                    f"-wb {ptweightsPath} hPtWeightsFONLLtimesTAMUBcent "
-                    f"-c {cent} -r {res_file} -o {output_dir} -s {suffix}_{iCutSets}"
-                )
-            
-            print(f"\033[32m{cmd}\033[0m")
-            os.system(cmd)
-
-        with concurrent.futures.ThreadPoolExecutor(max_workers=n_workers) as executor:
-            results_proj = list(executor.map(run_projections, range(mCutSets)))
-    else:
-        print("\033[33mWARNING: Projection for MC will not be performed\033[0m")
-
+	if 'ptWeights_path' in config and config['ptWeights_path'] != '':
+		given_ptweights = True
+		given_ptWeightsPath = config['ptWeights_path']
+		print(f"\033[32mINFO: Given pt weights {given_ptWeightsPath} will be used\033[0m")
+	else:
+		given_ptweights = False
 
 #___________________________________________________________________________________________________________________________
-    # Compute the efficiency
-    if efficiency:
-        check_dir(f"{output_dir}/eff")
-        EffPath = "./../compute_efficiency.py"
+	# make yaml file
+	if make_yaml:
+		check_dir(f"{output_dir}/config")
+		MakeyamlPath = './make_yaml_for_ml.py'
+		pre_process = "--preprocessed" if use_preprocessed else ""
 
-        def run_efficiency(i):
-            """Run efficiency computation for a given cutset index."""
-            iCutSets = f"{i:02d}"
-            print(f"\033[32mpython3 {EffPath} {config_flow} {output_dir}/proj/proj_{suffix}_{iCutSets}.root -c {cent} -o {output_dir} -s {suffix}_{iCutSets}\033[0m")
-            print(f"\033[32mProcessing cutset {iCutSets}\033[0m")
-            os.system(f"python3 {EffPath} {config_flow} {output_dir}/proj/proj_{suffix}_{iCutSets}.root -c {cent} -o {output_dir} -s {suffix}_{iCutSets} --batch")
-        
-        with concurrent.futures.ThreadPoolExecutor(max_workers=n_workers) as executor:
-            results_eff = list(executor.map(run_efficiency, range(mCutSets)))
-    else:
-        print("\033[33mWARNING: Efficiency will not be performed\033[0m")
+		print(f"\033[32mpython3 {MakeyamlPath} {config_flow} {pre_process} -o {output_dir} -s {suffix}\033[0m")
+		os.system(f"python3 {MakeyamlPath} {config_flow} {pre_process} -o {output_dir} -s {suffix}")
+	else:
+		print("\033[33mWARNING: Make yaml will not be performed\033[0m")
 
 #___________________________________________________________________________________________________________________________
-    # do the simulation fit to get the raw yields
-    if vn:
-        check_dir(f"{output_dir}/ry")
-        SimFitPath = "./../get_vn_vs_mass.py"
+	# Projection for MC and apply the ptweights
+	if proj:
+		check_dir(f"{output_dir}/proj")
+		ProjPath = "./proj_thn.py"
+		pre_process = "--preprocessed" if use_preprocessed else ""
+		anres_files = ' '.join(anres_dir)
 
-        def run_simfit(i):
-            """Run simulation fit for a given cutset index."""
-            iCutSets = f"{i:02d}"
-            print(f"\033[32mpython3 {SimFitPath} {config_flow} {cent} {output_dir}/proj/proj_{suffix}.root -o {output_dir}/ry -s _{suffix}_{iCutSets} -vn {vn_method}\033[0m")
-            print(f"\033[32mProcessing cutset {iCutSets}\033[0m")
-            os.system(f"python3 {SimFitPath} {config_flow} {cent} {output_dir}/proj/proj_{suffix}_{iCutSets}.root -o {output_dir}/ry -s _{suffix}_{iCutSets} -vn {vn_method} --batch")
-        
-        with concurrent.futures.ThreadPoolExecutor(max_workers=n_workers) as executor:
-            executor.map(run_simfit, range(mCutSets))
-    else:
-        print("\033[33mWARNING: vn extraction will not be performed\033[0m")
+		def run_projections(i):
+			"""Run simulation fit for a given cutset index."""
+			iCutSets = f"{i:02d}"
+			print(f"\033[32mProcessing cutset {iCutSets}...\033[0m")
 
-#___________________________________________________________________________________________________________________________
-    # Compute the fraction by cut variation method
-    if frac_cut_var:
-        check_dir(f"{output_dir}/CutVarFrac")
-        CurVarFracPath = "./compute_frac_cut_var.py"
+			if not os.path.exists(f"{output_dir}/ptweights/pTweight_{suffix}.root") and not given_ptweights:
+				# REVIEW: add the list of anres files
+				cmd = (
+					f"python3 {ProjPath} {config_flow} {output_dir}/config/cutset_{suffix}_{iCutSets}.yml {anres_files} {pre_process} "
+					f"-c {cent} -r {res_file} -o {output_dir} -s {suffix}_{iCutSets}"
+				)
+			else:
+				ptweightsPath = given_ptWeightsPath if given_ptweights else f"{output_dir}/ptweights/pTweight_{suffix}.root"
 
-        print(f"\033[32mpython3 {CurVarFracPath} {config_flow} {output_dir} -o {output_dir} -s {suffix}\033[0m")
-        os.system(f"python3 {CurVarFracPath} {config_flow} {output_dir} -o {output_dir} -s {suffix} --batch")
-    else:
-        print("\033[33mWARNING: Fraction by cut variation will not be performed\033[0m")
+				cmd = (
+					f"python3 {ProjPath} {config_flow} {output_dir}/config/cutset_{suffix}_{iCutSets}.yml {anres_files} {pre_process} "
+					f"-w {ptweightsPath} hPtWeightsFONLLtimesTAMUDcent "
+					f"-wb {ptweightsPath} hPtWeightsFONLLtimesTAMUBcent "
+					f"-c {cent} -r {res_file} -o {output_dir} -s {suffix}_{iCutSets}"
+				)
+			
+			print(f"\033[32m{cmd}\033[0m")
+			os.system(cmd)
 
-#___________________________________________________________________________________________________________________________
-    # Compute fraction by Data-driven method
-    if data_driven_frac:
-        check_dir(f"{output_dir}/DataDrivenFrac")
-        DataDrivenFracPath = "./ComputeDataDriFrac_flow.py"
+		with concurrent.futures.ThreadPoolExecutor(max_workers=n_workers) as executor:
+			results_proj = list(executor.map(run_projections, range(mCutSets)))
+	else:
+		print("\033[33mWARNING: Projection for MC will not be performed\033[0m")
 
-        # TODO: add the combined method with runing the correlated and uncorrelated at the same time
-        combined = config['combined'] if 'combined' in config else False
-        print(f"\033[32mCombined method: {combined}\033[0m")
-        if combined:
-            if config['minimisation']['correlated']:
-                print("\033[31mOnly support combined method when the minimisation is uncorrelated\033[0m")
-                print("\033[31mThe combined method will not be performed\033[0m")
-                # run the data-driven method with the corelated results
-                print(f"\033[32mpython3 {DataDrivenFracPath} -i {output_dir} -o {output_dir} -s {suffix} -b\033[0m")
-                main_data_driven_frac(inputdir=output_dir, outputdir=output_dir, suffix=suffix, batch=True, combined=False)
-            else:
-                # the path of corresponding results with correlated cut method
-                correlatedPath = config['correlatedPath'] if 'correlatedPath' in config else ''
-                if correlatedPath == '':
-                    print("\033[31mPlease provide the path to the corresponding correlated cut method\033[0m")
-                    correlatedPath = input("Path(`output_dir` in run_cutvar.sh): ")
-                correlatedCutVarPath = correlatedPath + '/cutvar_' + suffix
-                
-                # the path of the combined results
-                if 'pass3' in correlatedPath:
-                    outputdir_corr = output_dir.replace(f'{output_dir.split("/")[-2]}', 'combined_pass3')
-                else:
-                    outputdir_corr = output_dir.replace(f'{output_dir.split("/")[-2]}', 'combined')
-                check_dir(f"{outputdir_corr}/DataDrivenFrac")
-                
-                # run the data-driven method with the combined results and the uncorrelated results
-                print(f"\033[32mpython3 {DataDrivenFracPath} -i {output_dir} -o {output_dir} -s {suffix} -b -comb -cc {correlatedCutVarPath} -oc {outputdir_corr}\033[0m") 
-                main_data_driven_frac(inputdir=output_dir, outputdir=output_dir, suffix=suffix, batch=True, \
-                                        combined=True, correlatedCutVarPath=correlatedCutVarPath, outputdir_combined=outputdir_corr)
-
-        # run the data-driven method with the uncorrelated or correlated results
-        else:
-            print(f"\033[32mpython3 {DataDrivenFracPath} -i {output_dir} -o {output_dir} -s {suffix} -b\033[0m")
-            main_data_driven_frac(inputdir=output_dir, outputdir=output_dir, suffix=suffix, batch=True, combined=False)
-
-    else:
-        print("\033[33mWARNING: Fraction by Data-driven method will not be performed\033[0m")
 
 #___________________________________________________________________________________________________________________________
-    # Compute v2 vs fraction
-    if v2_vs_frac:
-        check_dir(f"{output_dir}/V2VsFrac")
-        v2vsFDFracPath = "./ComputeV2vsFDFrac.py"
-        
-        combined = config['combined'] if 'combined' in config else False
-        
-        if combined:
-            if 'pass3' in output_dir:
-                inputdir_combined = output_dir.replace(f'{output_dir.split("/")[-2]}', 'combined_pass3')
-            else:
-                inputdir_combined = output_dir.replace(f'{output_dir.split("/")[-2]}', 'combined')
-            outputdir_combined = inputdir_combined
-            check_dir(f"{outputdir_combined}/V2VsFrac")
-            
-            print(f"\033[32mthe combined method will be performed\033[0m")
-            print(f"\033[32mpython3 {v2vsFDFracPath} {config_flow} -i {output_dir} -o {output_dir} -s {suffix} -comb -ic {inputdir_combined} -oc {outputdir_combined}\033[0m")
-            main_v2_vs_frac(config=config_flow, inputdir=output_dir, outputdir=output_dir, suffix=suffix, \
-                                combined=True, inputdir_combined=inputdir_combined, outputdir_combined=outputdir_combined)
-        else:
-            print(f"\033[32mpython3 {v2vsFDFracPath} {config_flow} -i {output_dir} -o {output_dir} -s {suffix}\033[0m")
-            main_v2_vs_frac(config=config_flow, inputdir=output_dir, outputdir=output_dir, suffix=suffix, combined=False)
-    else:
-        print("\033[33mWARNING: v2 vs fraction will not be performed\033[0m")
+	# Compute the efficiency
+	if efficiency:
+		check_dir(f"{output_dir}/eff")
+		EffPath = "./../compute_efficiency.py"
+
+		def run_efficiency(i):
+			"""Run efficiency computation for a given cutset index."""
+			iCutSets = f"{i:02d}"
+			print(f"\033[32mpython3 {EffPath} {config_flow} {output_dir}/proj/proj_{suffix}_{iCutSets}.root -c {cent} -o {output_dir} -s {suffix}_{iCutSets}\033[0m")
+			print(f"\033[32mProcessing cutset {iCutSets}\033[0m")
+			os.system(f"python3 {EffPath} {config_flow} {output_dir}/proj/proj_{suffix}_{iCutSets}.root -c {cent} -o {output_dir} -s {suffix}_{iCutSets} --batch")
+		
+		with concurrent.futures.ThreadPoolExecutor(max_workers=n_workers) as executor:
+			results_eff = list(executor.map(run_efficiency, range(mCutSets)))
+	else:
+		print("\033[33mWARNING: Efficiency will not be performed\033[0m")
 
 #___________________________________________________________________________________________________________________________
-    # Merge cut var figures in multipanel images
-    if merge_images:
-        print(f"\033[32m\nCut_var_image_merger({config_flow}, {output_dir}, {suffix})\033[0m")
-        cut_var_image_merger(config, output_dir, suffix)
-    return
+	# do the simulation fit to get the raw yields
+	if vn:
+		check_dir(f"{output_dir}/ry")
+		SimFitPath = "./../get_vn_vs_mass.py"
+
+		def run_simfit(i):
+			"""Run simulation fit for a given cutset index."""
+			iCutSets = f"{i:02d}"
+			print(f"\033[32mpython3 {SimFitPath} {config_flow} {cent} {output_dir}/proj/proj_{suffix}.root -o {output_dir}/ry -s _{suffix}_{iCutSets} -vn {vn_method}\033[0m")
+			print(f"\033[32mProcessing cutset {iCutSets}\033[0m")
+			os.system(f"python3 {SimFitPath} {config_flow} {cent} {output_dir}/proj/proj_{suffix}_{iCutSets}.root -o {output_dir}/ry -s _{suffix}_{iCutSets} -vn {vn_method} --batch")
+		
+		with concurrent.futures.ThreadPoolExecutor(max_workers=n_workers) as executor:
+			executor.map(run_simfit, range(mCutSets))
+	else:
+		print("\033[33mWARNING: vn extraction will not be performed\033[0m")
+
+#___________________________________________________________________________________________________________________________
+	# Compute the fraction by cut variation method
+	if frac_cut_var:
+		check_dir(f"{output_dir}/CutVarFrac")
+		CurVarFracPath = "./compute_frac_cut_var.py"
+
+		print(f"\033[32mpython3 {CurVarFracPath} {config_flow} {output_dir} -o {output_dir} -s {suffix}\033[0m")
+		os.system(f"python3 {CurVarFracPath} {config_flow} {output_dir} -o {output_dir} -s {suffix} --batch")
+	else:
+		print("\033[33mWARNING: Fraction by cut variation will not be performed\033[0m")
+
+#___________________________________________________________________________________________________________________________
+	# Compute fraction by Data-driven method
+	if data_driven_frac:
+		check_dir(f"{output_dir}/DataDrivenFrac")
+		DataDrivenFracPath = "./ComputeDataDriFrac_flow.py"
+
+		# TODO: add the combined method with runing the correlated and uncorrelated at the same time
+		combined = config['combined'] if 'combined' in config else False
+		print(f"\033[32mCombined method: {combined}\033[0m")
+		if combined:
+			if config['minimisation']['correlated']:
+				print("\033[31mOnly support combined method when the minimisation is uncorrelated\033[0m")
+				print("\033[31mThe combined method will not be performed\033[0m")
+				# run the data-driven method with the corelated results
+				print(f"\033[32mpython3 {DataDrivenFracPath} -i {output_dir} -o {output_dir} -s {suffix} -b\033[0m")
+				main_data_driven_frac(inputdir=output_dir, outputdir=output_dir, suffix=suffix, batch=True, combined=False)
+			else:
+				# the path of corresponding results with correlated cut method
+				correlatedPath = config['correlatedPath'] if 'correlatedPath' in config else ''
+				if correlatedPath == '':
+					print("\033[31mPlease provide the path to the corresponding correlated cut method\033[0m")
+					correlatedPath = input("Path(`output_dir` in run_cutvar.sh): ")
+				correlatedCutVarPath = correlatedPath + '/cutvar_' + suffix
+				
+				# the path of the combined results
+				if 'pass3' in correlatedPath:
+					outputdir_corr = output_dir.replace(f'{output_dir.split("/")[-2]}', 'combined_pass3')
+				else:
+					outputdir_corr = output_dir.replace(f'{output_dir.split("/")[-2]}', 'combined')
+				check_dir(f"{outputdir_corr}/DataDrivenFrac")
+				
+				# run the data-driven method with the combined results and the uncorrelated results
+				print(f"\033[32mpython3 {DataDrivenFracPath} -i {output_dir} -o {output_dir} -s {suffix} -b -comb -cc {correlatedCutVarPath} -oc {outputdir_corr}\033[0m") 
+				main_data_driven_frac(inputdir=output_dir, outputdir=output_dir, suffix=suffix, batch=True, \
+										combined=True, correlatedCutVarPath=correlatedCutVarPath, outputdir_combined=outputdir_corr)
+
+		# run the data-driven method with the uncorrelated or correlated results
+		else:
+			print(f"\033[32mpython3 {DataDrivenFracPath} -i {output_dir} -o {output_dir} -s {suffix} -b\033[0m")
+			main_data_driven_frac(inputdir=output_dir, outputdir=output_dir, suffix=suffix, batch=True, combined=False)
+
+	else:
+		print("\033[33mWARNING: Fraction by Data-driven method will not be performed\033[0m")
+
+#___________________________________________________________________________________________________________________________
+	# Compute v2 vs fraction
+	if v2_vs_frac:
+		check_dir(f"{output_dir}/V2VsFrac")
+		v2vsFDFracPath = "./ComputeV2vsFDFrac.py"
+		
+		combined = config['combined'] if 'combined' in config else False
+		
+		if combined:
+			if 'pass3' in output_dir:
+				inputdir_combined = output_dir.replace(f'{output_dir.split("/")[-2]}', 'combined_pass3')
+			else:
+				inputdir_combined = output_dir.replace(f'{output_dir.split("/")[-2]}', 'combined')
+			outputdir_combined = inputdir_combined
+			check_dir(f"{outputdir_combined}/V2VsFrac")
+			
+			print(f"\033[32mthe combined method will be performed\033[0m")
+			print(f"\033[32mpython3 {v2vsFDFracPath} {config_flow} -i {output_dir} -o {output_dir} -s {suffix} -comb -ic {inputdir_combined} -oc {outputdir_combined}\033[0m")
+			main_v2_vs_frac(config=config_flow, inputdir=output_dir, outputdir=output_dir, suffix=suffix, \
+								combined=True, inputdir_combined=inputdir_combined, outputdir_combined=outputdir_combined)
+		else:
+			print(f"\033[32mpython3 {v2vsFDFracPath} {config_flow} -i {output_dir} -o {output_dir} -s {suffix}\033[0m")
+			main_v2_vs_frac(config=config_flow, inputdir=output_dir, outputdir=output_dir, suffix=suffix, combined=False)
+	else:
+		print("\033[33mWARNING: v2 vs fraction will not be performed\033[0m")
+
+#___________________________________________________________________________________________________________________________
+	# Merge cut var figures in multipanel images
+	if merge_images:
+		print(f"\033[32m\nCut_var_image_merger({config_flow}, {output_dir}, {suffix})\033[0m")
+		cut_var_image_merger(config, output_dir, suffix)
+	return
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description='Arguments')
-    parser.add_argument('flow_config', metavar='text', default='config_flow_d0.yml', help='configuration file')
-    parser.add_argument("--preprocessed", "-prep", action="store_true", help="use preprocessed input")
-    parser.add_argument("--do_calc_weights", "-cw", action="store_true", help="perform calculation of weights")
-    parser.add_argument("--do_make_yaml", "-my", action="store_true", help="perform make yaml")
-    parser.add_argument("--do_projections", "-pd", action="store_true", help="perform projections")
-    parser.add_argument("--do_efficiency", "-e", action="store_true", help="perform efficiency")
-    parser.add_argument("--do_vn", "-vn", action="store_true", help="perform vn extraction")
-    parser.add_argument("--do_frac_cut_var", "-f", action="store_true", help="perform fraction by cut variation")
-    parser.add_argument("--do_data_driven_frac", "-ddf", action="store_true", help="perform fraction by data-driven method")
-    parser.add_argument("--do_v2_vs_frac", "-v2fd", action="store_true", help="perform v2 vs FD fraction")
-    parser.add_argument("--do_merge_images", "-mergeim", action="store_true", help="perform v2 vs FD fraction")
-    args = parser.parse_args()
+	parser = argparse.ArgumentParser(description='Arguments')
+	parser.add_argument('flow_config', metavar='text', default='config_flow_d0.yml', help='configuration file')
+	parser.add_argument("--preprocessed", "-prep", action="store_true", help="use preprocessed input")
+	parser.add_argument("--do_calc_weights", "-cw", action="store_true", help="perform calculation of weights")
+	parser.add_argument("--do_make_yaml", "-my", action="store_true", help="perform make yaml")
+	parser.add_argument("--do_projections", "-pd", action="store_true", help="perform projections")
+	parser.add_argument("--do_efficiency", "-e", action="store_true", help="perform efficiency")
+	parser.add_argument("--do_vn", "-vn", action="store_true", help="perform vn extraction")
+	parser.add_argument("--do_frac_cut_var", "-f", action="store_true", help="perform fraction by cut variation")
+	parser.add_argument("--do_data_driven_frac", "-ddf", action="store_true", help="perform fraction by data-driven method")
+	parser.add_argument("--do_v2_vs_frac", "-v2fd", action="store_true", help="perform v2 vs FD fraction")
+	parser.add_argument("--do_merge_images", "-mergeim", action="store_true", help="perform v2 vs FD fraction")
+	args = parser.parse_args()
 
-    start_time = time.time()
-    print(f"args.do_projections: {args.do_projections}")
-    run_full_cut_variation(args.flow_config,
-                           args.preprocessed,
-                           args.do_calc_weights,
-                           args.do_make_yaml, 
-                           args.do_projections,
-                           args.do_efficiency, 
-                           args.do_vn,
-                           args.do_frac_cut_var, 
-                           args.do_data_driven_frac, 
-                           args.do_v2_vs_frac,
-                           args.do_merge_images)
+	start_time = time.time()
+	print(f"args.do_projections: {args.do_projections}")
+	run_full_cut_variation(args.flow_config,
+						   args.preprocessed,
+						   args.do_calc_weights,
+						   args.do_make_yaml, 
+						   args.do_projections,
+						   args.do_efficiency, 
+						   args.do_vn,
+						   args.do_frac_cut_var, 
+						   args.do_data_driven_frac, 
+						   args.do_v2_vs_frac,
+						   args.do_merge_images)
 
-    end_time = time.time()
-    execution_time = end_time - start_time
-    print(f"\033[34mTotal execution time: {execution_time:.2f} seconds\033[0m")
+	end_time = time.time()
+	execution_time = end_time - start_time
+	print(f"\033[34mTotal execution time: {execution_time:.2f} seconds\033[0m")
  

--- a/run3/flow/BDT/run_cutvar.sh
+++ b/run3/flow/BDT/run_cutvar.sh
@@ -2,119 +2,50 @@
 
 #Parameters
 #----------
-#- config (str): path of directory with config files
-#- an_res_file (str): path of directory with analysis results
-#- centrality (str): centrality class
-#- resolution (str/int): resolution file or resolution value
-#- outputdir (str): output directory
-#- suffix (str): suffix for output files
-#- vn_method (str): vn technique (sp, ep, deltaphi)
-#- skip_calc_weights (bool): skip calculation of weights
-#- skip_make_yaml (bool): skip make yaml
-#- skip_cut_variation (bool): skip cut variation
-#- skip_proj_mc (bool): skip projection for MC
-#- skip_efficiency (bool): skip efficiency
-#- skip_vn (bool): skip vn extraction
-#- skip_frac_cut_var (bool): skip fraction by cut variation
-#- skip_data_driven_frac (bool): skip fraction by data-driven method
-#- skip_v2_vs_frac (bool): skip v2 vs FD fraction
+# config_flow (str): path of directory with config files
+#- usepreprocessed (bool): use pre-processed input
+#- docw (bool): calculate pt weights
+#- domy (bool): produce yaml config files
+#- doproj (bool): project sparses (TODO: separate data and mc)
+#- doeff (bool): perform efficiency calculation
+#- dovn (bool): perform simultaneous fits
+#- dofcv (bool): perform fraction by cut variation
+#- doddf (bool): perform fraction by data-driven method
+#- dov2vf (bool): perform v2 vs FD fraction
+#- domergeimages (bool): perform cutvar images merging
 #----------
-export config_flow="path/to/config_flow.yml"
-export anres_dir="path/to/AnRes1.root \
-path/to/AnRes2.root \
-path/to/AnRes3.root \
-path/to/AnRes4.root \
-path/to/AnRes5.root"
-export output_dir="path/to/output" # full/corrected full/uncorrected
-export cent="k3050"
-export vn_method="sp"
-export res_file="path/to/resolution.root"
-export suffix="pt2_3" # _ will be added automatically
 
-export use_prep=False # True or False (use pre-processed inputs for projections)
-export spw=True # True or False (skip calculation of weights)
-export smy=True # True or False (skip make yaml)
-export spm=True # True or False (skip projection for MC)
-export seff=True # True or False (skip efficiency)
-export svn=True # True or False (skip vn extraction)
-export sfcv=True # True or False (skip fraction by cut variation)
-export sddf=True # True or False (skip fraction by data-driven method)
-export sv2vf=True # True or False (skip v2 vs fraction)
+export config_flow="/home/mdicosta/FlowDplus/FinalResults/templs_from_histo_parallel/config_3040_uncorrelated_templs_from_histo_parallel.yml"
+export usepreprocessed=True
+export docw=True
+export domy=True
+export doproj=True
+export doeff=True
+export dovn=True
+export dofcv=False
+export doddf=False
+export dov2vf=False
+export domergeimages=False
 
-# Setup logging
-TIMESTAMP=$(date +"%Y%m%d_%H%M%S")
-mkdir -p "${output_dir}/cutvar_${suffix}/logs"
-LOG_FILE="${output_dir}/cutvar_${suffix}/logs/log_${TIMESTAMP}.log"
-exec > >(tee -a "${LOG_FILE}") 2>&1
+export usepreprocessed=$([ "$usepreprocessed" = "false" ] && echo "" || echo "--use_preprocessed")
+export calc_weights=$([ "$docw" = "false" ] && echo "" || echo "--do_calc_weights")
+export make_yaml=$([ "$domy" = "false" ] && echo "" || echo "--do_make_yaml")
+export proj=$([ "$doproj" = "false" ] && echo "" || echo "--do_projections")
+export efficiency=$([ "$doeff" = "false" ] && echo "" || echo "--do_efficiency")
+export vn=$([ "$dovn" = "false" ] && echo "" || echo "--do_vn")
+export frac_cut_var=$([ "$dofcv" = "false" ] && echo "" || echo "--do_frac_cut_var")
+export data_driven_frac=$([ "$doddf" = "false" ] && echo "" || echo "--do_data_driven_frac")
+export v2_vs_frac=$([ "$dov2vf" = "false" ] && echo "" || echo "--do_v2_vs_frac")
+export merge_images=$([ "$domergeimages" = "false" ] && echo "" || echo "--do_merge_images")
 
-echo "Starting run_cutvar.sh at $(date)"
-echo "Logging to: ${LOG_FILE}"
-
-if [ $use_prep = False ]; then
-	export use_preprocessed=""
-else
-	export use_preprocessed="--preprocessed"
-fi
-
-if [ $spw = False ]; then
-	export skip_calc_weights=""
-else
-	export skip_calc_weights="--skip_calc_weights"
-fi
-
-if [ $smy = False ]; then
-	export skip_make_yaml=""
-else
-	export skip_make_yaml="--skip_make_yaml"
-fi
-
-if [ $spm = False ]; then
-	export skip_proj_mc=""
-else
-	export skip_proj_mc="--skip_proj_mc"
-fi
-
-if [ $seff = False ]; then
-	export skip_efficiency=""
-else
-	export skip_efficiency="--skip_efficiency"
-fi
-
-if [ $svn = False ]; then
-	export skip_vn=""
-else
-	export skip_vn="--skip_vn"
-fi
-
-if [ $sfcv = False ]; then
-	export skip_frac_cut_var=""
-else
-	export skip_frac_cut_var="--skip_frac_cut_var"
-fi
-
-if [ $sddf = False ]; then
-	export skip_data_driven_frac=""
-else
-	export skip_data_driven_frac="--skip_data_driven_frac"
-fi
-
-if [ $sv2vf = False ]; then
-	export skip_v2_vs_frac=""
-else
-	export skip_v2_vs_frac="--skip_v2_vs_frac"
-fi
-
-python3 run_cutvar.py $config_flow $anres_dir -c $cent -r $res_file -o $output_dir -s $suffix -vn $vn_method $use_preprocessed \
-						$skip_calc_weights \
-						$skip_make_yaml \
-						$skip_proj_mc \
-						$skip_efficiency \
-						$skip_vn \
-						$skip_frac_cut_var \
-						$skip_data_driven_frac \
-						$skip_v2_vs_frac
-
-echo "Completed run_cutvar.sh at $(date)"
-echo "Log saved to: ${LOG_FILE}"
-
-python3 /home/wuct/ALICE/local/DmesonAnalysis/run3/tool/clean_logs.py $LOG_FILE
+python3 run_cutvar.py $config_flow \
+					  $usepreprocessed \
+					  $calc_weights \
+					  $make_yaml \
+					  $proj \
+					  $efficiency \
+					  $vn \
+					  $frac_cut_var \
+					  $data_driven_frac \
+					  $v2_vs_frac \
+					  $merge_images

--- a/run3/flow/BDT/run_cutvar.sh
+++ b/run3/flow/BDT/run_cutvar.sh
@@ -27,16 +27,16 @@ export doddf=False
 export dov2vf=False
 export domergeimages=False
 
-export usepreprocessed=$([ "$usepreprocessed" = "false" ] && echo "" || echo "--use_preprocessed")
-export calc_weights=$([ "$docw" = "false" ] && echo "" || echo "--do_calc_weights")
-export make_yaml=$([ "$domy" = "false" ] && echo "" || echo "--do_make_yaml")
-export proj=$([ "$doproj" = "false" ] && echo "" || echo "--do_projections")
-export efficiency=$([ "$doeff" = "false" ] && echo "" || echo "--do_efficiency")
-export vn=$([ "$dovn" = "false" ] && echo "" || echo "--do_vn")
-export frac_cut_var=$([ "$dofcv" = "false" ] && echo "" || echo "--do_frac_cut_var")
-export data_driven_frac=$([ "$doddf" = "false" ] && echo "" || echo "--do_data_driven_frac")
-export v2_vs_frac=$([ "$dov2vf" = "false" ] && echo "" || echo "--do_v2_vs_frac")
-export merge_images=$([ "$domergeimages" = "false" ] && echo "" || echo "--do_merge_images")
+export usepreprocessed=$([ "$usepreprocessed" = "False" ] && echo "" || echo "--use_preprocessed")
+export calc_weights=$([ "$docw" = "False" ] && echo "" || echo "--do_calc_weights")
+export make_yaml=$([ "$domy" = "False" ] && echo "" || echo "--do_make_yaml")
+export proj=$([ "$doproj" = "False" ] && echo "" || echo "--do_projections")
+export efficiency=$([ "$doeff" = "False" ] && echo "" || echo "--do_efficiency")
+export vn=$([ "$dovn" = "False" ] && echo "" || echo "--do_vn")
+export frac_cut_var=$([ "$dofcv" = "False" ] && echo "" || echo "--do_frac_cut_var")
+export data_driven_frac=$([ "$doddf" = "False" ] && echo "" || echo "--do_data_driven_frac")
+export v2_vs_frac=$([ "$dov2vf" = "False" ] && echo "" || echo "--do_v2_vs_frac")
+export merge_images=$([ "$domergeimages" = "False" ] && echo "" || echo "--do_merge_images")
 
 python3 run_cutvar.py $config_flow \
 					  $usepreprocessed \

--- a/run3/flow/BDT/sparse_dicts.py
+++ b/run3/flow/BDT/sparse_dicts.py
@@ -24,7 +24,6 @@ def get_sparses(config, get_data, get_mc_reco, get_mc_gen, anres_files=[], prepr
     
     
     sparsesFlow, sparsesReco, sparsesGen, axes_dict = {}, {}, {}, {}    
-    
     if get_data:
         if preprocessed:
             # REVIEW: sperate the config_pre and config_flow
@@ -34,8 +33,8 @@ def get_sparses(config, get_data, get_mc_reco, get_mc_gen, anres_files=[], prepr
                 raise ValueError("Error: ptmins and ptmaxs in config_pre.yaml do not match the ones in the config.yaml")
             axes_dict['Flow'] = {ax: iax for iax, ax in enumerate(config_pre['axestokeep'])}
             for ptmin, ptmax in zip(config_pre['ptmins'], config_pre['ptmaxs']):
-                print(f"Loading flow sparse from file: {preprocess_dir}/AnalysisResults_pt_{int(ptmin*10)}_{int(ptmax*10)}.root")
-                infileflow = TFile(f"{preprocess_dir}/AnalysisResults_pt_{int(ptmin*10)}_{int(ptmax*10)}.root")
+                print(f"Loading flow sparse from file: {preprocess_dir}/pre/AnRes/AnalysisResults_pt_{int(ptmin*10)}_{int(ptmax*10)}.root")
+                infileflow = TFile(f"{preprocess_dir}/pre/AnRes/AnalysisResults_pt_{int(ptmin*10)}_{int(ptmax*10)}.root")
                 sparsesFlow[f'Flow_{ptmin*10}_{ptmax*10}'] = infileflow.Get('hf-task-flow-charm-hadrons/hSparseFlowCharm')
                 infileflow.Close()
         else:

--- a/run3/flow/BDT/sparse_dicts.py
+++ b/run3/flow/BDT/sparse_dicts.py
@@ -23,7 +23,8 @@ def get_sparses(config, get_data, get_mc_reco, get_mc_gen, anres_files=[], prepr
     """
     
     
-    sparsesFlow, sparsesReco, sparsesGen, axes_dict = {}, {}, {}, {}    
+    sparsesFlow, sparsesReco, sparsesGen, axes_dict = {}, {}, {}, {}
+
     if get_data:
         if preprocessed:
             # REVIEW: sperate the config_pre and config_flow

--- a/run3/flow/config_flow.yml
+++ b/run3/flow/config_flow.yml
@@ -14,6 +14,21 @@ axes: {mass: 0,
        bdt_bkg: 6,
        bdt_sig: 7}
 
+# cut variation general configurables
+centrality: 'k3040' # centrality class
+res_file: '/path/to/resofile.root' 
+out_dir: '/path/to/output/dir'
+suffix: 'suffix'
+anresdir: [
+    "path/to/AnRes1.root",
+    "path/to/AnRes2.root",
+    "path/to/AnRes3.root",
+    "path/to/AnRes4.root",
+    "path/to/AnRes5.root"
+]
+vn_method: 'sp'
+nworkers: 1 # workers to parallelize projections, efficiency and fitting
+
 harmonic: 2 # 2: v2, 3: v3, etc.
 
 # pt bins

--- a/run3/flow/config_flow.yml
+++ b/run3/flow/config_flow.yml
@@ -49,7 +49,7 @@ use_inv_mass_bins: false # use binning in invariant mass distribution, neglects 
 
 # ep/sp subevents
 detA: 'FT0c'
-detB: 'FT0a'
+detB: 'FV0a'
 detC: 'TPCpos'
 
 #________________________________________________________________________________________________________________________
@@ -128,7 +128,7 @@ minimisation:
     #            [], # pt 5
     #            [], # pt 6
     #]
-    #systematics: ['minus3', 'even', 'odd', 'random']
+    #systematics: ['even', 'random', 'odd', 'minus3low', '1in3', '1in4', 'minus3high', 'minus3']
 
 # efficiency
 eff_filename: 'task_output.root'

--- a/run3/flow/config_flow.yml
+++ b/run3/flow/config_flow.yml
@@ -120,6 +120,15 @@ minimisation:
     combined: False
     # `output_dir` in run_cutvar.sh
     correlatedPath: 'path/to/correlated'
+    #skip_cuts: [    # index of the specific cuts to skip for each pt bin
+    #            [], # pt 1
+    #            [], # pt 2
+    #            [], # pt 3
+    #            [], # pt 4
+    #            [], # pt 5
+    #            [], # pt 6
+    #]
+    #systematics: ['minus3', 'even', 'odd', 'random']
 
 # efficiency
 eff_filename: 'task_output.root'

--- a/run3/flow/flow_analysis_utils.py
+++ b/run3/flow/flow_analysis_utils.py
@@ -8,6 +8,11 @@ import sys
 import ctypes
 from itertools import combinations
 import numpy as np
+import fitz  # PyMuPDF
+from PIL import Image
+import math
+import glob
+import re
 
 def get_vn_versus_mass(thnSparses, inv_mass_bins, mass_axis, vn_axis, debug=False):
     '''

--- a/run3/flow/flow_analysis_utils.py
+++ b/run3/flow/flow_analysis_utils.py
@@ -881,7 +881,7 @@ def get_cut_sets_config(config):
 
 def cut_var_image_merger(config, cut_var_dir, suffix):
 
-    def pdf_to_images(pdf_path, dpi=300):
+    def pdf_to_images(pdf_path, dpi=100):
         """Extract high-quality images from a PDF."""
         doc = fitz.open(pdf_path)
         images = []
@@ -931,7 +931,7 @@ def cut_var_image_merger(config, cut_var_dir, suffix):
         if len(pdf_list) == 0:
             raise ValueError("No PDF provided!")
 
-        images = [pdf_to_images(pdf, dpi=300) for pdf in pdf_list]
+        images = [pdf_to_images(pdf, dpi=100) for pdf in pdf_list]
         num_pages = min(len(imgs) for imgs in images)
 
         os.makedirs(output_folder, exist_ok=True)


### PR DESCRIPTION
According to the discussion I had with @wuctlby and @stefanopolitano, this PR introduces the following changes:
- The bash script to launch the `run_cutvar.py` script is simplified to take only the yaml cfg file as input, and the flags to decide which parts of the preprocessing to run
- The logic of the switches is changed from skip (.sh) --> if not (.py) conditions to do (.sh) --> if (.py) conditions 
- The settings which are related to the analysis, i.e. centrality, resolution file, input files, vn extraction technique are moved to the yaml config file

Furthermore, the possibility of parallelizing the sparse projection, efficiency computation and vn extraction is added. Finally, an utility function, `cut_var_image_merger`, is added in order to gather the relevant QA plots of the cut variation per pt bin in a single image (to be put in presentations).

By now, I still haven't been able to address the `REVIEW` comments left by Chuntai, I will do it in a following PR. Please let me know if you want me to change something!